### PR TITLE
set base path to /edge/v1

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -289,6 +289,7 @@ func NewAppEnv(c *edgeConfig.Config) *AppEnv {
 	if err != nil {
 		pfxlog.Logger().Fatalln(err)
 	}
+
 	api := operations.NewZitiEdgeAPI(swaggerSpec)
 	api.ServeError = ServeError
 	// See README.md in /ziti/edge/embedded for details
@@ -318,6 +319,7 @@ func NewAppEnv(c *edgeConfig.Config) *AppEnv {
 	//enrollment consumer, leave content unread, allow modules to read
 	api.ApplicationXPemFileConsumer = noOpConsumer
 	api.ApplicationPkcs10Consumer = noOpConsumer
+
 
 	api.ApplicationXPemFileProducer = &TextProducer{}
 	api.ZtSessionAuth = func(token string) (principal interface{}, err error) {

--- a/controller/internal/routes/base_router.go
+++ b/controller/internal/routes/base_router.go
@@ -192,9 +192,9 @@ func ListWithEnvelopeFactory(rc *response.RequestContext, toEnvelope ApiListEnve
 
 	meta := &rest_model.Meta{
 		Pagination: &rest_model.Pagination{
-			Limit:      result.Limit,
-			Offset:     result.Offset,
-			TotalCount: result.Count,
+			Limit:      &result.Limit,
+			Offset:     &result.Offset,
+			TotalCount: &result.Count,
 		},
 		FilterableFields: result.FilterableFields,
 	}
@@ -429,12 +429,16 @@ func listWithId(rc *response.RequestContext, f func(id string) ([]interface{}, e
 
 	count := len(results)
 
+	limit := int64(count)
+	offset := int64(0)
+	totalCount := int64(count)
+
 	meta := &rest_model.Meta{
 		FilterableFields: []string{},
 		Pagination: &rest_model.Pagination{
-			Limit:      int64(count),
-			Offset:     0,
-			TotalCount: int64(count),
+			Limit:      &limit,
+			Offset:     &offset,
+			TotalCount: &totalCount,
 		},
 	}
 
@@ -533,9 +537,9 @@ func ListAssociations(rc *response.RequestContext, listF listAssocF) {
 
 	meta := &rest_model.Meta{
 		Pagination: &rest_model.Pagination{
-			Limit:      result.Limit,
-			Offset:     result.Offset,
-			TotalCount: result.Count,
+			Limit:      &result.Limit,
+			Offset:     &result.Offset,
+			TotalCount: &result.Count,
 		},
 		FilterableFields: result.FilterableFields,
 	}

--- a/rest_client/ziti_edge_client.go
+++ b/rest_client/ziti_edge_client.go
@@ -66,7 +66,7 @@ const (
 	DefaultHost string = "demo.ziti.dev"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
-	DefaultBasePath string = "/"
+	DefaultBasePath string = "/edge/v1"
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file

--- a/rest_model/pagination.go
+++ b/rest_model/pagination.go
@@ -30,8 +30,10 @@ package rest_model
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Pagination pagination
@@ -40,17 +42,64 @@ import (
 type Pagination struct {
 
 	// limit
-	Limit int64 `json:"limit,omitempty"`
+	// Required: true
+	Limit *int64 `json:"limit"`
 
 	// offset
-	Offset int64 `json:"offset,omitempty"`
+	// Required: true
+	Offset *int64 `json:"offset"`
 
 	// total count
-	TotalCount int64 `json:"totalCount,omitempty"`
+	// Required: true
+	TotalCount *int64 `json:"totalCount"`
 }
 
 // Validate validates this pagination
 func (m *Pagination) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateLimit(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateOffset(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTotalCount(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Pagination) validateLimit(formats strfmt.Registry) error {
+
+	if err := validate.Required("limit", "body", m.Limit); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Pagination) validateOffset(formats strfmt.Registry) error {
+
+	if err := validate.Required("offset", "body", m.Offset); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Pagination) validateTotalCount(formats strfmt.Registry) error {
+
+	if err := validate.Required("totalCount", "body", m.TotalCount); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/rest_server/doc.go
+++ b/rest_server/doc.go
@@ -28,8 +28,8 @@
 //  Schemes:
 //    https
 //  Host: demo.ziti.dev
-//  BasePath: /
-//  Version: 0.14.0
+//  BasePath: /edge/v1
+//  Version: 0.15.0
 //  Contact:
 //
 //  Consumes:

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -55,10 +55,10 @@ func init() {
   "info": {
     "title": "Ziti Edge",
     "contact": {},
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "host": "demo.ziti.dev",
-  "basePath": "/",
+  "basePath": "/edge/v1",
   "paths": {
     "/": {
       "get": {
@@ -6689,6 +6689,11 @@ func init() {
     },
     "pagination": {
       "type": "object",
+      "required": [
+        "limit",
+        "offset",
+        "totalCount"
+      ],
       "properties": {
         "limit": {
           "type": "number",
@@ -8299,10 +8304,10 @@ func init() {
   "info": {
     "title": "Ziti Edge",
     "contact": {},
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "host": "demo.ziti.dev",
-  "basePath": "/",
+  "basePath": "/edge/v1",
   "paths": {
     "/": {
       "get": {
@@ -22213,6 +22218,11 @@ func init() {
     },
     "pagination": {
       "type": "object",
+      "required": [
+        "limit",
+        "offset",
+        "totalCount"
+      ],
       "properties": {
         "limit": {
           "type": "number",

--- a/rest_server/operations/api_session/delete_api_sessions_urlbuilder.go
+++ b/rest_server/operations/api_session/delete_api_sessions_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteAPISessionsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/api_session/detail_api_sessions_urlbuilder.go
+++ b/rest_server/operations/api_session/detail_api_sessions_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailAPISessionsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/api_session/list_api_sessions_urlbuilder.go
+++ b/rest_server/operations/api_session/list_api_sessions_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListAPISessionsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authentication/authenticate_urlbuilder.go
+++ b/rest_server/operations/authentication/authenticate_urlbuilder.go
@@ -67,7 +67,7 @@ func (o *AuthenticateURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/create_authenticator_urlbuilder.go
+++ b/rest_server/operations/authenticator/create_authenticator_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/delete_authenticator_urlbuilder.go
+++ b/rest_server/operations/authenticator/delete_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/detail_authenticator_urlbuilder.go
+++ b/rest_server/operations/authenticator/detail_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/list_authenticators_urlbuilder.go
+++ b/rest_server/operations/authenticator/list_authenticators_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListAuthenticatorsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/patch_authenticator_urlbuilder.go
+++ b/rest_server/operations/authenticator/patch_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/authenticator/update_authenticator_urlbuilder.go
+++ b/rest_server/operations/authenticator/update_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/create_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/create_ca_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/delete_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/delete_ca_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/detail_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/detail_ca_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/get_ca_jwt_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/get_ca_jwt_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *GetCaJwtURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/list_cas_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/list_cas_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListCasURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/patch_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/patch_ca_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/update_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/update_ca_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/certificate_authority/verify_ca_urlbuilder.go
+++ b/rest_server/operations/certificate_authority/verify_ca_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *VerifyCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/create_config_type_urlbuilder.go
+++ b/rest_server/operations/config/create_config_type_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/create_config_urlbuilder.go
+++ b/rest_server/operations/config/create_config_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/delete_config_type_urlbuilder.go
+++ b/rest_server/operations/config/delete_config_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/delete_config_urlbuilder.go
+++ b/rest_server/operations/config/delete_config_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/detail_config_type_urlbuilder.go
+++ b/rest_server/operations/config/detail_config_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/detail_config_urlbuilder.go
+++ b/rest_server/operations/config/detail_config_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/list_config_types_urlbuilder.go
+++ b/rest_server/operations/config/list_config_types_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListConfigTypesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/list_configs_for_config_type_urlbuilder.go
+++ b/rest_server/operations/config/list_configs_for_config_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListConfigsForConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/list_configs_urlbuilder.go
+++ b/rest_server/operations/config/list_configs_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListConfigsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/patch_config_type_urlbuilder.go
+++ b/rest_server/operations/config/patch_config_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/patch_config_urlbuilder.go
+++ b/rest_server/operations/config/patch_config_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/update_config_type_urlbuilder.go
+++ b/rest_server/operations/config/update_config_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateConfigTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/config/update_config_urlbuilder.go
+++ b/rest_server/operations/config/update_config_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/delete_current_api_session_urlbuilder.go
+++ b/rest_server/operations/current_api_session/delete_current_api_session_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *DeleteCurrentAPISessionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/detail_current_identity_authenticator_urlbuilder.go
+++ b/rest_server/operations/current_api_session/detail_current_identity_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailCurrentIdentityAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/get_current_api_session_urlbuilder.go
+++ b/rest_server/operations/current_api_session/get_current_api_session_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *GetCurrentAPISessionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/get_current_identity_urlbuilder.go
+++ b/rest_server/operations/current_api_session/get_current_identity_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *GetCurrentIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/list_current_identity_authenticators_urlbuilder.go
+++ b/rest_server/operations/current_api_session/list_current_identity_authenticators_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListCurrentIdentityAuthenticatorsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/patch_current_identity_authenticator_urlbuilder.go
+++ b/rest_server/operations/current_api_session/patch_current_identity_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchCurrentIdentityAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/current_api_session/update_current_identity_authenticator_urlbuilder.go
+++ b/rest_server/operations/current_api_session/update_current_identity_authenticator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateCurrentIdentityAuthenticatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/create_edge_router_urlbuilder.go
+++ b/rest_server/operations/edge_router/create_edge_router_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateEdgeRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/delete_edge_router_urlbuilder.go
+++ b/rest_server/operations/edge_router/delete_edge_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteEdgeRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/detail_edge_router_urlbuilder.go
+++ b/rest_server/operations/edge_router/detail_edge_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailEdgeRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/list_edge_router_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/edge_router/list_edge_router_edge_router_policies_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/list_edge_router_identities_urlbuilder.go
+++ b/rest_server/operations/edge_router/list_edge_router_identities_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterIdentitiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/list_edge_router_service_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/edge_router/list_edge_router_service_edge_router_policies_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterServiceEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/list_edge_router_services_urlbuilder.go
+++ b/rest_server/operations/edge_router/list_edge_router_services_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterServicesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/list_edge_routers_urlbuilder.go
+++ b/rest_server/operations/edge_router/list_edge_routers_urlbuilder.go
@@ -73,7 +73,7 @@ func (o *ListEdgeRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/patch_edge_router_urlbuilder.go
+++ b/rest_server/operations/edge_router/patch_edge_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchEdgeRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router/update_edge_router_urlbuilder.go
+++ b/rest_server/operations/edge_router/update_edge_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateEdgeRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/create_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/create_edge_router_policy_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/delete_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/delete_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/detail_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/detail_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/list_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/list_edge_router_policies_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/list_edge_router_policy_edge_routers_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/list_edge_router_policy_edge_routers_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterPolicyEdgeRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/list_edge_router_policy_identities_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/list_edge_router_policy_identities_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListEdgeRouterPolicyIdentitiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/patch_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/patch_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/edge_router_policy/update_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/edge_router_policy/update_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/enroll_ca_urlbuilder.go
+++ b/rest_server/operations/enroll/enroll_ca_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *EnrollCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/enroll_er_ott_urlbuilder.go
+++ b/rest_server/operations/enroll/enroll_er_ott_urlbuilder.go
@@ -69,7 +69,7 @@ func (o *EnrollErOttURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/enroll_ott_ca_urlbuilder.go
+++ b/rest_server/operations/enroll/enroll_ott_ca_urlbuilder.go
@@ -69,7 +69,7 @@ func (o *EnrollOttCaURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/enroll_ott_urlbuilder.go
+++ b/rest_server/operations/enroll/enroll_ott_urlbuilder.go
@@ -69,7 +69,7 @@ func (o *EnrollOttURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/enroll_urlbuilder.go
+++ b/rest_server/operations/enroll/enroll_urlbuilder.go
@@ -69,7 +69,7 @@ func (o *EnrollURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enroll/ernoll_updb_urlbuilder.go
+++ b/rest_server/operations/enroll/ernoll_updb_urlbuilder.go
@@ -69,7 +69,7 @@ func (o *ErnollUpdbURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enrollment/delete_enrollment_urlbuilder.go
+++ b/rest_server/operations/enrollment/delete_enrollment_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteEnrollmentURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enrollment/detail_enrollment_urlbuilder.go
+++ b/rest_server/operations/enrollment/detail_enrollment_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailEnrollmentURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/enrollment/list_enrollments_urlbuilder.go
+++ b/rest_server/operations/enrollment/list_enrollments_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListEnrollmentsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/geo_region/detail_geo_region_urlbuilder.go
+++ b/rest_server/operations/geo_region/detail_geo_region_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailGeoRegionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/geo_region/list_geo_regions_urlbuilder.go
+++ b/rest_server/operations/geo_region/list_geo_regions_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListGeoRegionsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/associate_identitys_service_configs_urlbuilder.go
+++ b/rest_server/operations/identity/associate_identitys_service_configs_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *AssociateIdentitysServiceConfigsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/create_identity_urlbuilder.go
+++ b/rest_server/operations/identity/create_identity_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/delete_identity_urlbuilder.go
+++ b/rest_server/operations/identity/delete_identity_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/detail_identity_type_urlbuilder.go
+++ b/rest_server/operations/identity/detail_identity_type_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailIdentityTypeURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/detail_identity_urlbuilder.go
+++ b/rest_server/operations/identity/detail_identity_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/disassociate_identitys_service_configs_urlbuilder.go
+++ b/rest_server/operations/identity/disassociate_identitys_service_configs_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DisassociateIdentitysServiceConfigsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/get_identity_policy_advice_urlbuilder.go
+++ b/rest_server/operations/identity/get_identity_policy_advice_urlbuilder.go
@@ -83,7 +83,7 @@ func (o *GetIdentityPolicyAdviceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identities_urlbuilder.go
+++ b/rest_server/operations/identity/list_identities_urlbuilder.go
@@ -73,7 +73,7 @@ func (o *ListIdentitiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identity_edge_routers_urlbuilder.go
+++ b/rest_server/operations/identity/list_identity_edge_routers_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListIdentityEdgeRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identity_service_policies_urlbuilder.go
+++ b/rest_server/operations/identity/list_identity_service_policies_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListIdentityServicePoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identity_services_urlbuilder.go
+++ b/rest_server/operations/identity/list_identity_services_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListIdentityServicesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identity_types_urlbuilder.go
+++ b/rest_server/operations/identity/list_identity_types_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListIdentityTypesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identitys_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/identity/list_identitys_edge_router_policies_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListIdentitysEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/list_identitys_service_configs_urlbuilder.go
+++ b/rest_server/operations/identity/list_identitys_service_configs_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListIdentitysServiceConfigsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/patch_identity_urlbuilder.go
+++ b/rest_server/operations/identity/patch_identity_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/identity/update_identity_urlbuilder.go
+++ b/rest_server/operations/identity/update_identity_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/detail_spec_body_urlbuilder.go
+++ b/rest_server/operations/informational/detail_spec_body_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailSpecBodyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/detail_spec_urlbuilder.go
+++ b/rest_server/operations/informational/detail_spec_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailSpecURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/list_root_urlbuilder.go
+++ b/rest_server/operations/informational/list_root_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListRootURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/list_specs_urlbuilder.go
+++ b/rest_server/operations/informational/list_specs_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListSpecsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/list_summary_urlbuilder.go
+++ b/rest_server/operations/informational/list_summary_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListSummaryURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/informational/list_version_urlbuilder.go
+++ b/rest_server/operations/informational/list_version_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListVersionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/role_attributes/list_edge_router_role_attributes_urlbuilder.go
+++ b/rest_server/operations/role_attributes/list_edge_router_role_attributes_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListEdgeRouterRoleAttributesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/role_attributes/list_identity_role_attributes_urlbuilder.go
+++ b/rest_server/operations/role_attributes/list_identity_role_attributes_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListIdentityRoleAttributesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/role_attributes/list_service_role_attributes_urlbuilder.go
+++ b/rest_server/operations/role_attributes/list_service_role_attributes_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListServiceRoleAttributesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/create_service_urlbuilder.go
+++ b/rest_server/operations/service/create_service_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/delete_service_urlbuilder.go
+++ b/rest_server/operations/service/delete_service_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/detail_service_urlbuilder.go
+++ b/rest_server/operations/service/detail_service_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_config_urlbuilder.go
+++ b/rest_server/operations/service/list_service_config_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_edge_routers_urlbuilder.go
+++ b/rest_server/operations/service/list_service_edge_routers_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceEdgeRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_identities_urlbuilder.go
+++ b/rest_server/operations/service/list_service_identities_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceIdentitiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_service_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/service/list_service_service_edge_router_policies_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceServiceEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_service_policies_urlbuilder.go
+++ b/rest_server/operations/service/list_service_service_policies_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceServicePoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_service_terminators_urlbuilder.go
+++ b/rest_server/operations/service/list_service_terminators_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServiceTerminatorsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/list_services_urlbuilder.go
+++ b/rest_server/operations/service/list_services_urlbuilder.go
@@ -73,7 +73,7 @@ func (o *ListServicesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/patch_service_urlbuilder.go
+++ b/rest_server/operations/service/patch_service_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service/update_service_urlbuilder.go
+++ b/rest_server/operations/service/update_service_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/create_service_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/create_service_edge_router_policy_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateServiceEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/delete_service_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/delete_service_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteServiceEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/detail_service_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/detail_service_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailServiceEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/list_service_edge_router_policies_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/list_service_edge_router_policies_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListServiceEdgeRouterPoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/list_service_edge_router_policy_edge_routers_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/list_service_edge_router_policy_edge_routers_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListServiceEdgeRouterPolicyEdgeRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/list_service_edge_router_policy_services_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/list_service_edge_router_policy_services_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *ListServiceEdgeRouterPolicyServicesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/patch_service_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/patch_service_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchServiceEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_edge_router_policy/update_service_edge_router_policy_urlbuilder.go
+++ b/rest_server/operations/service_edge_router_policy/update_service_edge_router_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateServiceEdgeRouterPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/create_service_policy_urlbuilder.go
+++ b/rest_server/operations/service_policy/create_service_policy_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateServicePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/delete_service_policy_urlbuilder.go
+++ b/rest_server/operations/service_policy/delete_service_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteServicePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/detail_service_policy_urlbuilder.go
+++ b/rest_server/operations/service_policy/detail_service_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailServicePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/list_service_policies_urlbuilder.go
+++ b/rest_server/operations/service_policy/list_service_policies_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListServicePoliciesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/list_service_policy_identities_urlbuilder.go
+++ b/rest_server/operations/service_policy/list_service_policy_identities_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServicePolicyIdentitiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/list_service_policy_services_urlbuilder.go
+++ b/rest_server/operations/service_policy/list_service_policy_services_urlbuilder.go
@@ -81,7 +81,7 @@ func (o *ListServicePolicyServicesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/patch_service_policy_urlbuilder.go
+++ b/rest_server/operations/service_policy/patch_service_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchServicePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/service_policy/update_service_policy_urlbuilder.go
+++ b/rest_server/operations/service_policy/update_service_policy_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateServicePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/session/create_session_urlbuilder.go
+++ b/rest_server/operations/session/create_session_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateSessionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/session/delete_session_urlbuilder.go
+++ b/rest_server/operations/session/delete_session_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteSessionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/session/detail_session_urlbuilder.go
+++ b/rest_server/operations/session/detail_session_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailSessionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/session/list_sessions_urlbuilder.go
+++ b/rest_server/operations/session/list_sessions_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListSessionsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/create_terminator_urlbuilder.go
+++ b/rest_server/operations/terminator/create_terminator_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateTerminatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/delete_terminator_urlbuilder.go
+++ b/rest_server/operations/terminator/delete_terminator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteTerminatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/detail_terminator_urlbuilder.go
+++ b/rest_server/operations/terminator/detail_terminator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailTerminatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/list_terminators_urlbuilder.go
+++ b/rest_server/operations/terminator/list_terminators_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListTerminatorsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/patch_terminator_urlbuilder.go
+++ b/rest_server/operations/terminator/patch_terminator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchTerminatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/terminator/update_terminator_urlbuilder.go
+++ b/rest_server/operations/terminator/update_terminator_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateTerminatorURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/create_transit_router_urlbuilder.go
+++ b/rest_server/operations/transit_router/create_transit_router_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *CreateTransitRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/delete_transit_router_urlbuilder.go
+++ b/rest_server/operations/transit_router/delete_transit_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DeleteTransitRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/detail_transit_router_urlbuilder.go
+++ b/rest_server/operations/transit_router/detail_transit_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *DetailTransitRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/list_transit_routers_urlbuilder.go
+++ b/rest_server/operations/transit_router/list_transit_routers_urlbuilder.go
@@ -71,7 +71,7 @@ func (o *ListTransitRoutersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/patch_transit_router_urlbuilder.go
+++ b/rest_server/operations/transit_router/patch_transit_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *PatchTransitRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/transit_router/update_transit_router_urlbuilder.go
+++ b/rest_server/operations/transit_router/update_transit_router_urlbuilder.go
@@ -75,7 +75,7 @@ func (o *UpdateTransitRouterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/rest_server/operations/well_known/list_well_known_cas_urlbuilder.go
+++ b/rest_server/operations/well_known/list_well_known_cas_urlbuilder.go
@@ -63,7 +63,7 @@ func (o *ListWellKnownCasURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/"
+		_basePath = "/edge/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -1,11 +1,11 @@
 ---
 swagger: '2.0'
 info:
-  version: 0.14.0
+  version: 0.15.0
   title: Ziti Edge
   contact: {}
 host: demo.ziti.dev
-basePath: /
+basePath: /edge/v1
 schemes:
   - https
 consumes:
@@ -5289,6 +5289,10 @@ definitions:
       type: string
   pagination:
     type: object
+    required:
+      - limit
+      - offset
+      - totalCount
     properties:
       limit:
         type: number


### PR DESCRIPTION
- reroute API requests for the root to edge/v1 (i.e. / -> /edge/v1)
- fix pagination empty values being omitted


Author's Note: anything under `rest_server` `rest_client` are generated code. Reviewing swagger.yml will give you the source change.