### PR TITLE
Add.api.versions.to.versions

### DIFF
--- a/controller/internal/routes/base_entity_api_model.go
+++ b/controller/internal/routes/base_entity_api_model.go
@@ -63,7 +63,8 @@ func (factory *BasicLinkFactory) SelfLinkFromId(id string) rest_model.Link {
 }
 
 func (factory *BasicLinkFactory) SelfUrlString(id string) string {
-	return path.Join(".", factory.entityName, id)
+	//path.Join will remove the ./ prefix in its "clean" operation
+	return "./" + path.Join(factory.entityName, id)
 }
 
 func (factory *BasicLinkFactory) SelfLink(entity models.Entity) rest_model.Link {
@@ -78,7 +79,8 @@ func (factory *BasicLinkFactory) Links(entity models.Entity) rest_model.Links {
 
 func (factory BasicLinkFactory) NewNestedLink(entity models.Entity, elem ...string) rest_model.Link {
 	elem = append([]string{factory.SelfUrlString(entity.GetId())}, elem...)
-	return NewLink(path.Join(elem...))
+	//path.Join will remove the ./ prefix in its "clean" operation
+	return NewLink("./" + path.Join(elem...))
 }
 
 func (factory *BasicLinkFactory) EntityName() string {

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -19,6 +19,7 @@ package routes
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/openziti/edge/build"
+	"github.com/openziti/edge/controller"
 	"github.com/openziti/edge/controller/env"
 	"github.com/openziti/edge/controller/internal/permissions"
 	"github.com/openziti/edge/controller/response"
@@ -53,14 +54,23 @@ func (ir *VersionRouter) Register(ae *env.AppEnv) {
 }
 
 func (ir *VersionRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
-
 	buildInfo := build.GetBuildInfo()
 	data := rest_model.Version{
 		BuildDate:      buildInfo.GetBuildDate(),
 		Revision:       buildInfo.GetRevision(),
 		RuntimeVersion: runtime.Version(),
 		Version:        buildInfo.GetVersion(),
+		APIVersions: []*rest_model.APIVersion{
+			mapApiVersionToRestModel(controller.RestApiV1, controller.RestApiBaseUrlV1),
+		},
+	}
+	rc.RespondWithOk(data, nil)
+}
+
+func mapApiVersionToRestModel(version, path string) *rest_model.APIVersion {
+	return &rest_model.APIVersion{
+		Path:    &path,
+		Version: &version,
 	}
 
-	rc.RespondWithOk(data, nil)
 }

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -53,23 +53,22 @@ func (ir *VersionRouter) Register(ae *env.AppEnv) {
 	})
 }
 
-func (ir *VersionRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
+func (ir *VersionRouter) List(_ *env.AppEnv, rc *response.RequestContext) {
 	buildInfo := build.GetBuildInfo()
 	data := rest_model.Version{
 		BuildDate:      buildInfo.GetBuildDate(),
 		Revision:       buildInfo.GetRevision(),
 		RuntimeVersion: runtime.Version(),
 		Version:        buildInfo.GetVersion(),
-		APIVersions: map[string][]rest_model.APIVersion{
-			"edge": {mapApiVersionToRestModel(controller.RestApiV1, controller.RestApiBaseUrlV1)},
+		APIVersions: map[string]map[string]rest_model.APIVersion{
+			"edge": {controller.RestApiV1: mapApiVersionToRestModel(controller.RestApiBaseUrlV1)},
 		},
 	}
 	rc.RespondWithOk(data, &rest_model.Meta{})
 }
 
-func mapApiVersionToRestModel(version, path string) rest_model.APIVersion {
+func mapApiVersionToRestModel(path string) rest_model.APIVersion {
 	return rest_model.APIVersion{
 		Path:    &path,
-		Version: &version,
 	}
 }

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -60,17 +60,16 @@ func (ir *VersionRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
 		Revision:       buildInfo.GetRevision(),
 		RuntimeVersion: runtime.Version(),
 		Version:        buildInfo.GetVersion(),
-		APIVersions: []*rest_model.APIVersion{
-			mapApiVersionToRestModel(controller.RestApiV1, controller.RestApiBaseUrlV1),
+		APIVersions: map[string][]rest_model.APIVersion{
+			"edge": {mapApiVersionToRestModel(controller.RestApiV1, controller.RestApiBaseUrlV1)},
 		},
 	}
 	rc.RespondWithOk(data, &rest_model.Meta{})
 }
 
-func mapApiVersionToRestModel(version, path string) *rest_model.APIVersion {
-	return &rest_model.APIVersion{
+func mapApiVersionToRestModel(version, path string) rest_model.APIVersion {
+	return rest_model.APIVersion{
 		Path:    &path,
 		Version: &version,
 	}
-
 }

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -64,7 +64,7 @@ func (ir *VersionRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
 			mapApiVersionToRestModel(controller.RestApiV1, controller.RestApiBaseUrlV1),
 		},
 	}
-	rc.RespondWithOk(data, nil)
+	rc.RespondWithOk(data, &rest_model.Meta{})
 }
 
 func mapApiVersionToRestModel(version, path string) *rest_model.APIVersion {

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -20,6 +20,7 @@ import "C"
 import (
 	"context"
 	"fmt"
+	"github.com/openziti/edge/controller"
 	"net/http"
 	"os"
 	"os/signal"
@@ -59,10 +60,6 @@ const (
 	policyMaxFreq     = 1 * time.Hour
 	policyAppWanFreq  = 1 * time.Second
 	policySessionFreq = 5 * time.Second
-
-	restApiBase          = "/edge/"
-	restApiBaseUrlV1     = "/edge/v1"
-	restApiBaseUrlLatest = restApiBaseUrlV1
 )
 
 func NewController(cfg config.Configurable) (*Controller, error) {
@@ -245,8 +242,8 @@ func (c *Controller) Run() {
 
 	as := newApiServer(c.config, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		//if not edge prefix, translate to "/edge/v<latest>"
-		if !strings.HasPrefix(request.URL.Path, restApiBase) {
-			request.URL.Path = restApiBaseUrlLatest + request.URL.Path
+		if !strings.HasPrefix(request.URL.Path, controller.RestApiBase) {
+			request.URL.Path = controller.RestApiBaseUrlLatest + request.URL.Path
 		}
 
 		//let the OpenApi http router take over

--- a/controller/versions.go
+++ b/controller/versions.go
@@ -1,0 +1,25 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package controller
+
+const (
+	RestApiBase = "/edge/"
+
+	RestApiV1            = "v1"
+	RestApiBaseUrlV1     = "/edge/" + RestApiV1
+	RestApiBaseUrlLatest = RestApiBaseUrlV1
+)

--- a/rest_model/api_version.go
+++ b/rest_model/api_version.go
@@ -46,8 +46,7 @@ type APIVersion struct {
 	Path *string `json:"path"`
 
 	// version
-	// Required: true
-	Version *string `json:"version"`
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this api version
@@ -55,10 +54,6 @@ func (m *APIVersion) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validatePath(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateVersion(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -71,15 +66,6 @@ func (m *APIVersion) Validate(formats strfmt.Registry) error {
 func (m *APIVersion) validatePath(formats strfmt.Registry) error {
 
 	if err := validate.Required("path", "body", m.Path); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *APIVersion) validateVersion(formats strfmt.Registry) error {
-
-	if err := validate.Required("version", "body", m.Version); err != nil {
 		return err
 	}
 

--- a/rest_model/api_version.go
+++ b/rest_model/api_version.go
@@ -30,39 +30,35 @@ package rest_model
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"strconv"
-
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
-// Version version
+// APIVersion api version
 //
-// swagger:model version
-type Version struct {
+// swagger:model apiVersion
+type APIVersion struct {
 
-	// api versions
-	APIVersions []*APIVersion `json:"apiVersions"`
-
-	// build date
-	BuildDate string `json:"buildDate,omitempty"`
-
-	// revision
-	Revision string `json:"revision,omitempty"`
-
-	// runtime version
-	RuntimeVersion string `json:"runtimeVersion,omitempty"`
+	// path
+	// Required: true
+	Path *string `json:"path"`
 
 	// version
-	Version string `json:"version,omitempty"`
+	// Required: true
+	Version *string `json:"version"`
 }
 
-// Validate validates this version
-func (m *Version) Validate(formats strfmt.Registry) error {
+// Validate validates this api version
+func (m *APIVersion) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAPIVersions(formats); err != nil {
+	if err := m.validatePath(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVersion(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -72,33 +68,26 @@ func (m *Version) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Version) validateAPIVersions(formats strfmt.Registry) error {
+func (m *APIVersion) validatePath(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.APIVersions) { // not required
-		return nil
+	if err := validate.Required("path", "body", m.Path); err != nil {
+		return err
 	}
 
-	for i := 0; i < len(m.APIVersions); i++ {
-		if swag.IsZero(m.APIVersions[i]) { // not required
-			continue
-		}
+	return nil
+}
 
-		if m.APIVersions[i] != nil {
-			if err := m.APIVersions[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("apiVersions" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
+func (m *APIVersion) validateVersion(formats strfmt.Registry) error {
 
+	if err := validate.Required("version", "body", m.Version); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 // MarshalBinary interface implementation
-func (m *Version) MarshalBinary() ([]byte, error) {
+func (m *APIVersion) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -106,8 +95,8 @@ func (m *Version) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *Version) UnmarshalBinary(b []byte) error {
-	var res Version
+func (m *APIVersion) UnmarshalBinary(b []byte) error {
+	var res APIVersion
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/rest_model/version.go
+++ b/rest_model/version.go
@@ -30,8 +30,6 @@ package rest_model
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"strconv"
-
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -44,7 +42,7 @@ import (
 type Version struct {
 
 	// api versions
-	APIVersions map[string][]APIVersion `json:"apiVersions,omitempty"`
+	APIVersions map[string]map[string]APIVersion `json:"apiVersions,omitempty"`
 
 	// build date
 	BuildDate string `json:"buildDate,omitempty"`
@@ -81,17 +79,15 @@ func (m *Version) validateAPIVersions(formats strfmt.Registry) error {
 
 	for k := range m.APIVersions {
 
-		if err := validate.Required("apiVersions"+"."+k, "body", m.APIVersions[k]); err != nil {
-			return err
-		}
+		for kk := range m.APIVersions[k] {
 
-		for i := 0; i < len(m.APIVersions[k]); i++ {
-
-			if err := m.APIVersions[k][i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("apiVersions" + "." + k + "." + strconv.Itoa(i))
-				}
+			if err := validate.Required("apiVersions"+"."+k+"."+kk, "body", m.APIVersions[k][kk]); err != nil {
 				return err
+			}
+			if val, ok := m.APIVersions[k][kk]; ok {
+				if err := val.Validate(formats); err != nil {
+					return err
+				}
 			}
 
 		}

--- a/rest_model/version.go
+++ b/rest_model/version.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Version version
@@ -43,7 +44,7 @@ import (
 type Version struct {
 
 	// api versions
-	APIVersions []*APIVersion `json:"apiVersions"`
+	APIVersions map[string][]APIVersion `json:"apiVersions,omitempty"`
 
 	// build date
 	BuildDate string `json:"buildDate,omitempty"`
@@ -78,18 +79,21 @@ func (m *Version) validateAPIVersions(formats strfmt.Registry) error {
 		return nil
 	}
 
-	for i := 0; i < len(m.APIVersions); i++ {
-		if swag.IsZero(m.APIVersions[i]) { // not required
-			continue
+	for k := range m.APIVersions {
+
+		if err := validate.Required("apiVersions"+"."+k, "body", m.APIVersions[k]); err != nil {
+			return err
 		}
 
-		if m.APIVersions[i] != nil {
-			if err := m.APIVersions[i].Validate(formats); err != nil {
+		for i := 0; i < len(m.APIVersions[k]); i++ {
+
+			if err := m.APIVersions[k][i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("apiVersions" + "." + strconv.Itoa(i))
+					return ve.ValidateName("apiVersions" + "." + k + "." + strconv.Itoa(i))
 				}
 				return err
 			}
+
 		}
 
 	}

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -4612,8 +4612,7 @@ func init() {
     "apiVersion": {
       "type": "object",
       "required": [
-        "path",
-        "version"
+        "path"
       ],
       "properties": {
         "path": {
@@ -7680,8 +7679,8 @@ func init() {
         "apiVersions": {
           "type": "object",
           "additionalProperties": {
-            "type": "array",
-            "items": {
+            "type": "object",
+            "additionalProperties": {
               "$ref": "#/definitions/apiVersion"
             }
           }
@@ -20165,8 +20164,7 @@ func init() {
     "apiVersion": {
       "type": "object",
       "required": [
-        "path",
-        "version"
+        "path"
       ],
       "properties": {
         "path": {
@@ -23234,8 +23232,8 @@ func init() {
         "apiVersions": {
           "type": "object",
           "additionalProperties": {
-            "type": "array",
-            "items": {
+            "type": "object",
+            "additionalProperties": {
               "$ref": "#/definitions/apiVersion"
             }
           }

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -4609,6 +4609,21 @@ func init() {
         "$ref": "#/definitions/apiSessionDetail"
       }
     },
+    "apiVersion": {
+      "type": "object",
+      "required": [
+        "path",
+        "version"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
     "attributes": {
       "description": "A set of strings used to loosly couple this resource to policies",
       "type": "array",
@@ -7662,6 +7677,12 @@ func init() {
     "version": {
       "type": "object",
       "properties": {
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiVersion"
+          }
+        },
         "buildDate": {
           "type": "string",
           "example": "2020-02-11 16:09:08"
@@ -20138,6 +20159,21 @@ func init() {
         "$ref": "#/definitions/apiSessionDetail"
       }
     },
+    "apiVersion": {
+      "type": "object",
+      "required": [
+        "path",
+        "version"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
     "attributes": {
       "description": "A set of strings used to loosly couple this resource to policies",
       "type": "array",
@@ -23192,6 +23228,12 @@ func init() {
     "version": {
       "type": "object",
       "properties": {
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiVersion"
+          }
+        },
         "buildDate": {
           "type": "string",
           "example": "2020-02-11 16:09:08"

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -7678,9 +7678,12 @@ func init() {
       "type": "object",
       "properties": {
         "apiVersions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiVersion"
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/apiVersion"
+            }
           }
         },
         "buildDate": {
@@ -23229,9 +23232,12 @@ func init() {
       "type": "object",
       "properties": {
         "apiVersions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiVersion"
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/apiVersion"
+            }
           }
         },
         "buildDate": {

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -4899,14 +4899,13 @@ definitions:
       apiVersions:
         type: object
         additionalProperties:
-          type: array
-          items:
+          type: object
+          additionalProperties:
             $ref: '#/definitions/apiVersion'
   apiVersion:
     type: object
     required:
       - path
-      - version
     properties:
       version:
         type: string

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -4896,6 +4896,20 @@ definitions:
       version:
         type: string
         example: 'v0.9.0'
+      apiVersions:
+        type: array
+        items:
+          $ref: '#/definitions/apiVersion'
+  apiVersion:
+    type: object
+    required:
+      - path
+      - version
+    properties:
+      version:
+        type: string
+      path:
+        type: string
   listSummaryCounts:
     type: object
     additionalProperties:

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -4897,9 +4897,11 @@ definitions:
         type: string
         example: 'v0.9.0'
       apiVersions:
-        type: array
-        items:
-          $ref: '#/definitions/apiVersion'
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            $ref: '#/definitions/apiVersion'
   apiVersion:
     type: object
     required:


### PR DESCRIPTION
example:

```
{
    "data": {
        "apiVersions": {
            "edge": {
                "v1": {
                    "path": "/edge/v1"
                }
            }
        },
        "buildDate": "2020-06-11 16:03:13",
        "revision": "95e78d4bc64b",
        "runtimeVersion": "go1.14.3",
        "version": "v0.14.13"
    },
    "meta": {}
}
```