### PR TITLE
Fix.specs.not.found.240

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -293,6 +293,7 @@ func NewAppEnv(c *edgeConfig.Config) *AppEnv {
 	api.ApplicationXPemFileConsumer = noOpConsumer
 	api.ApplicationPkcs10Consumer = noOpConsumer
 	api.ApplicationXPemFileProducer = &PemProducer{}
+	api.TextYamlProducer = &YamlProducer{}
 	api.ZtSessionAuth = func(token string) (principal interface{}, err error) {
 		principal, err = ae.GetHandlers().ApiSession.ReadByToken(token)
 

--- a/controller/env/producers.go
+++ b/controller/env/producers.go
@@ -18,6 +18,7 @@ package env
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 )
@@ -40,4 +41,12 @@ func (p PemProducer) Produce(writer io.Writer, i interface{}) error {
 		return err
 	}
 	return fmt.Errorf("unsupported type for PEM producer: %T", i)
+}
+
+
+type YamlProducer struct{}
+
+func (p YamlProducer) Produce(writer io.Writer, i interface{}) error {
+	enc := yaml.NewEncoder(writer)
+	return enc.Encode(i)
 }

--- a/controller/internal/routes/spec_router.go
+++ b/controller/internal/routes/spec_router.go
@@ -1,0 +1,163 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/edge/build"
+	"github.com/openziti/edge/controller/env"
+	"github.com/openziti/edge/controller/internal/permissions"
+	"github.com/openziti/edge/controller/response"
+	"github.com/openziti/edge/rest_model"
+	"github.com/openziti/edge/rest_server"
+	"github.com/openziti/edge/rest_server/operations/informational"
+	"github.com/openziti/fabric/controller/models"
+	"time"
+)
+
+const EntityNameSpecs = "specs"
+
+var SpecLinkFactory = NewSpecLinkFactory()
+
+type SpecLinkFactoryImpl struct {
+	BasicLinkFactory
+}
+
+func NewSpecLinkFactory() *SpecLinkFactoryImpl {
+	return &SpecLinkFactoryImpl{
+		BasicLinkFactory{entityName: EntityNameSpecs},
+	}
+}
+
+func (factory *SpecLinkFactoryImpl) Links(entity models.Entity) rest_model.Links {
+	links := factory.BasicLinkFactory.Links(entity)
+	links["spec"] = factory.NewNestedLink(entity, "spec")
+
+	return links
+}
+
+type Spec struct {
+	models.BaseEntity
+	name string
+	body map[string]interface{}
+}
+
+var swaggerSpec *Spec
+var specs []*Spec
+
+func init() {
+	info := build.GetBuildInfo()
+	date := time.Now()
+	if info.GetBuildDate() != "unknown" {
+		var err error
+		date, err = time.Parse("", info.GetBuildDate())
+		if err != nil {
+			pfxlog.Logger().WithError(err).Warn("could not parse build info date for swagger spec")
+		}
+	}
+	swaggerSpec = &Spec{
+		BaseEntity: models.BaseEntity{
+			Id:        "swagger",
+			CreatedAt: date,
+			UpdatedAt: date,
+			Tags:      map[string]interface{}{},
+		},
+		name: "swagger",
+	}
+
+	err := json.Unmarshal(rest_server.SwaggerJSON, &swaggerSpec.body)
+	if err != nil {
+		pfxlog.Logger().WithError(err).Panic("could not parse rest server JSON spec")
+	}
+
+	specs = append(specs, swaggerSpec)
+
+	r := NewSpecRouter()
+	env.AddRouter(r)
+}
+
+type SpecRouter struct {
+	BasePath string
+}
+
+func NewSpecRouter() *SpecRouter {
+	return &SpecRouter{
+		BasePath: "/specs",
+	}
+}
+
+func (r *SpecRouter) Register(ae *env.AppEnv) {
+	ae.Api.InformationalListSpecsHandler = informational.ListSpecsHandlerFunc(func(params informational.ListSpecsParams) middleware.Responder {
+		return ae.IsAllowed(r.List, params.HTTPRequest, "", "", permissions.Always())
+	})
+
+	ae.Api.InformationalDetailSpecHandler = informational.DetailSpecHandlerFunc(func(params informational.DetailSpecParams) middleware.Responder {
+		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.Always())
+	})
+
+	ae.Api.InformationalDetailSpecBodyHandler = informational.DetailSpecBodyHandlerFunc(func(params informational.DetailSpecBodyParams) middleware.Responder {
+		return ae.IsAllowed(r.DetailBody, params.HTTPRequest, params.ID, "", permissions.Always())
+	})
+}
+
+func (r *SpecRouter) List(_ *env.AppEnv, rc *response.RequestContext) {
+	data := rest_model.SpecList{
+		mapSpecToRestModel(swaggerSpec),
+	}
+
+	rc.RespondWithOk(data, &rest_model.Meta{})
+}
+
+func (r *SpecRouter) Detail(_ *env.AppEnv, rc *response.RequestContext) {
+	id, err := rc.GetEntityId()
+	if err != nil {
+		rc.RespondWithError(fmt.Errorf("entity id not set"))
+	}
+	for _, spec := range specs {
+		if spec.GetId() == id {
+			rc.RespondWithOk(mapSpecToRestModel(spec), &rest_model.Meta{})
+			return
+		}
+	}
+
+	rc.RespondWithNotFound()
+}
+
+func (r *SpecRouter) DetailBody(_ *env.AppEnv, rc *response.RequestContext) {
+	id, err := rc.GetEntityId()
+	if err != nil {
+		rc.RespondWithError(fmt.Errorf("entity id not set"))
+	}
+	for _, spec := range specs {
+		if spec.GetId() == id {
+			_ = rc.GetProducer().Produce(rc.ResponseWriter, spec.body)
+			return
+		}
+	}
+
+	rc.RespondWithNotFound()
+}
+
+func mapSpecToRestModel(spec *Spec) *rest_model.SpecDetail {
+	return &rest_model.SpecDetail{
+		BaseEntity: BaseEntityToRestModel(spec, SpecLinkFactory),
+		Name:       &spec.name,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -47,4 +47,6 @@ require (
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	gopkg.in/resty.v1 v1.12.0
+	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/rest_client/informational/informational_client.go
+++ b/rest_client/informational/informational_client.go
@@ -117,7 +117,7 @@ func (a *Client) DetailSpecBody(params *DetailSpecBodyParams) (*DetailSpecBodyOK
 		ID:                 "detailSpecBody",
 		Method:             "GET",
 		PathPattern:        "/specs/{id}/spec",
-		ProducesMediaTypes: []string{"text/yaml"},
+		ProducesMediaTypes: []string{"application/json", "text/yaml"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -4056,7 +4056,8 @@ func init() {
         "security": [],
         "description": "Return the body of the specification (i.e. Swagger, OpenAPI 2.0, 3.0, etc).",
         "produces": [
-          "text/yaml"
+          "text/yaml",
+          "application/json"
         ],
         "tags": [
           "Informational"
@@ -18827,6 +18828,7 @@ func init() {
         "security": [],
         "description": "Return the body of the specification (i.e. Swagger, OpenAPI 2.0, 3.0, etc).",
         "produces": [
+          "application/json",
           "text/yaml"
         ],
         "tags": [

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -166,7 +166,6 @@ paths:
       summary: Return a single spec resource
       description: Returns single spec resource embedded within the controller for consumption/documentation/code geneartion
       security: []
-      consumes:
       tags:
         - Informational
       operationId: detailSpec

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -166,6 +166,7 @@ paths:
       summary: Return a single spec resource
       description: Returns single spec resource embedded within the controller for consumption/documentation/code geneartion
       security: []
+      consumes:
       tags:
         - Informational
       operationId: detailSpec
@@ -184,6 +185,7 @@ paths:
       operationId: detailSpecBody
       produces:
         - text/yaml
+        - application/json
       responses:
         '200':
           $ref: '#/responses/detailSpecBody'

--- a/tests/specs_test.go
+++ b/tests/specs_test.go
@@ -1,0 +1,144 @@
+// +build apitests
+
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"encoding/json"
+	"github.com/Jeffail/gabs"
+	"gopkg.in/resty.v1"
+	"gopkg.in/yaml.v2"
+	"net/http"
+	"testing"
+)
+
+func Test_Specs(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	var resp *resty.Response
+
+	t.Run("specs can be listed", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		var err error
+		resp, err = ctx.unauthenticatedSession().newRequest(ctx).Get("edge/v1/specs")
+		ctx.Req.NoError(err)
+
+		standardJsonResponseTests(resp, http.StatusOK, t)
+
+		t.Run("contains swagger spec", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			parsed, err := gabs.ParseJSON(resp.Body())
+			ctx.Req.NoError(err)
+
+			children, err := parsed.Path("data").Children()
+			ctx.Req.NoError(err)
+
+			ctx.Req.Len(children, 1)
+
+			id := children[0].Path("id").Data().(string)
+
+			ctx.Req.Equal("swagger", id)
+		})
+	})
+
+	t.Run("swagger spec can be detailed", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		resp, err := ctx.unauthenticatedSession().newRequest(ctx).Get("edge/v1/specs/swagger")
+		ctx.Req.NoError(err)
+
+		standardJsonResponseTests(resp, http.StatusOK, t)
+
+		t.Run("contains the swagger spec", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			parsed, err := gabs.ParseJSON(resp.Body())
+			ctx.Req.NoError(err)
+
+			data := parsed.Path("data")
+			id := data.Path("id").Data().(string)
+			ctx.Req.Equal("swagger", id)
+		})
+	})
+
+	t.Run("swagger spec body can be retrieved as text/yaml", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		resp, err := ctx.unauthenticatedSession().newRequest(ctx).
+			SetHeader("accept", "text/yaml").
+			Get("edge/v1/specs/swagger/spec")
+		ctx.Req.NoError(err)
+
+		t.Run("has a 200 ok status", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+		})
+
+		t.Run("has text/yaml content type", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Equal("text/yaml", resp.Header().Get("content-type"))
+		})
+
+		t.Run("has a yaml parsable body", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			out := map[string]interface{}{}
+			err := yaml.Unmarshal(resp.Body(), &out)
+			ctx.Req.NoError(err)
+
+			t.Run("parsed yaml body has non zero length", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				ctx.Req.NotEmpty(out)
+			})
+
+		})
+	})
+
+	t.Run("swagger spec body can be retrieved as application/json", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		resp, err := ctx.unauthenticatedSession().newRequest(ctx).
+			SetHeader("accept", "application/json").
+			Get("edge/v1/specs/swagger/spec")
+		ctx.Req.NoError(err)
+
+		t.Run("has a 200 ok status", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+		})
+
+		t.Run("has application/json content type", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Equal("application/json", resp.Header().Get("content-type"))
+		})
+
+		t.Run("has a json parsable body", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			out := map[string]interface{}{}
+			err := json.Unmarshal(resp.Body(), &out)
+			ctx.Req.NoError(err)
+
+			t.Run("parsed json body has non zero length", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				ctx.Req.NotEmpty(out)
+			})
+
+		})
+	})
+}


### PR DESCRIPTION
- adds spec router
- updates swagger to allow for both JSON and YAML spec bodies
- pulls spec from generated rest server