### PR TITLE
set edge router result list to all

### DIFF
--- a/controller/model/edge_router_handlers.go
+++ b/controller/model/edge_router_handlers.go
@@ -130,7 +130,9 @@ func (handler *EdgeRouterHandler) ListForSession(sessionId string) (*EdgeRouterL
 			return err
 		}
 
-		result, err = handler.ListForIdentityAndServiceWithTx(tx, apiSession.IdentityId, session.ServiceId, nil)
+		limit := -1
+
+		result, err = handler.ListForIdentityAndServiceWithTx(tx, apiSession.IdentityId, session.ServiceId, &limit)
 		return err
 	})
 	return result, err


### PR DESCRIPTION
- all is denoted by -1 which is actualy the max for int64