### PR TITLE
adds public ip address for #226

### DIFF
--- a/controller/internal/routes/api_session_api_model.go
+++ b/controller/internal/routes/api_session_api_model.go
@@ -60,6 +60,7 @@ func MapApiSessionToRestModel(apiSession *model.ApiSession) (*rest_model.APISess
 		IdentityID:  &apiSession.IdentityId,
 		Identity:    ToEntityRef(apiSession.Identity.Name, apiSession.Identity, IdentityLinkFactory),
 		Token:       &apiSession.Token,
+		IPAddress:   &apiSession.IPAddress,
 		ConfigTypes: stringz.SetToSlice(apiSession.ConfigTypes),
 	}
 	return ret, nil

--- a/controller/internal/routes/authenticate_router.go
+++ b/controller/internal/routes/authenticate_router.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openziti/edge/rest_server/operations/authentication"
 	"github.com/openziti/foundation/metrics"
 	"github.com/openziti/foundation/util/stringz"
+	"net"
 	"net/http"
 	"time"
 )
@@ -113,12 +114,17 @@ func (ro *AuthRouter) authHandler(ae *env.AppEnv, rc *response.RequestContext, p
 	if params.Body != nil {
 		configTypes = mapConfigTypeNamesToIds(ae, params.Body.ConfigTypes, identity.Id)
 	}
+	remoteIpStr := ""
+	if remoteIp, _, err := net.SplitHostPort(rc.Request.RemoteAddr); err == nil {
+		remoteIpStr = remoteIp
+	}
 
 	logger.Debugf("client %v requesting configTypes: %v", identity.Name, configTypes)
 	s := &model.ApiSession{
 		IdentityId:  identity.Id,
 		Token:       token,
 		ConfigTypes: configTypes,
+		IPAddress:   remoteIpStr,
 	}
 	sessionId, err := ae.Handlers.ApiSession.Create(s)
 

--- a/controller/internal/routes/current_api_session_api_model.go
+++ b/controller/internal/routes/current_api_session_api_model.go
@@ -58,6 +58,7 @@ func MapToCurrentApiSessionRestModel(s *model.ApiSession, sessionTimeout time.Du
 			Identity:    ToEntityRef(s.Identity.Name, s.Identity, IdentityLinkFactory),
 			Token:       &s.Token,
 			ConfigTypes: stringz.SetToSlice(s.ConfigTypes),
+			IPAddress:   &s.IPAddress,
 		},
 		ExpiresAt: &expiresAt,
 	}

--- a/controller/model/api_session_model.go
+++ b/controller/model/api_session_model.go
@@ -32,6 +32,7 @@ type ApiSession struct {
 	Token       string
 	IdentityId  string
 	Identity    *Identity
+	IPAddress   string
 	ConfigTypes map[string]struct{}
 }
 
@@ -45,6 +46,7 @@ func (entity *ApiSession) toBoltEntity(tx *bbolt.Tx, handler Handler) (boltz.Ent
 		Token:         entity.Token,
 		IdentityId:    entity.IdentityId,
 		ConfigTypes:   stringz.SetToSlice(entity.ConfigTypes),
+		IPAddress:     entity.IPAddress,
 	}
 
 	return boltEntity, nil
@@ -71,6 +73,7 @@ func (entity *ApiSession) fillFrom(handler Handler, tx *bbolt.Tx, boltEntity bol
 	entity.Token = boltApiSession.Token
 	entity.IdentityId = boltApiSession.IdentityId
 	entity.ConfigTypes = stringz.SliceToSet(boltApiSession.ConfigTypes)
+	entity.IPAddress = boltApiSession.IPAddress
 	boltIdentity, err := handler.GetEnv().GetStores().Identity.LoadOneById(tx, boltApiSession.IdentityId)
 	if err != nil {
 		return err

--- a/controller/persistence/api_session_store.go
+++ b/controller/persistence/api_session_store.go
@@ -27,12 +27,14 @@ const (
 	FieldApiSessionIdentity    = "identity"
 	FieldApiSessionToken       = "token"
 	FieldApiSessionConfigTypes = "configTypes"
+	FieldApiSessionIPAddress   = "ipAddress"
 )
 
 type ApiSession struct {
 	boltz.BaseExtEntity
 	IdentityId  string
 	Token       string
+	IPAddress   string
 	ConfigTypes []string
 }
 
@@ -49,6 +51,7 @@ func (entity *ApiSession) LoadValues(_ boltz.CrudStore, bucket *boltz.TypedBucke
 	entity.IdentityId = bucket.GetStringOrError(FieldApiSessionIdentity)
 	entity.Token = bucket.GetStringOrError(FieldApiSessionToken)
 	entity.ConfigTypes = bucket.GetStringList(FieldApiSessionConfigTypes)
+	entity.IPAddress = bucket.GetStringWithDefault(FieldApiSessionIPAddress, "")
 }
 
 func (entity *ApiSession) SetValues(ctx *boltz.PersistContext) {
@@ -56,6 +59,7 @@ func (entity *ApiSession) SetValues(ctx *boltz.PersistContext) {
 	ctx.SetString(FieldApiSessionIdentity, entity.IdentityId)
 	ctx.SetString(FieldApiSessionToken, entity.Token)
 	ctx.SetStringList(FieldApiSessionConfigTypes, entity.ConfigTypes)
+	ctx.SetString(FieldApiSessionIPAddress, entity.IPAddress)
 }
 
 func (entity *ApiSession) GetEntityType() string {

--- a/rest_model/api_session_detail.go
+++ b/rest_model/api_session_detail.go
@@ -54,6 +54,10 @@ type APISessionDetail struct {
 	// Required: true
 	IdentityID *string `json:"identityId"`
 
+	// ip address
+	// Required: true
+	IPAddress *string `json:"ipAddress"`
+
 	// token
 	// Required: true
 	Token *string `json:"token"`
@@ -76,6 +80,8 @@ func (m *APISessionDetail) UnmarshalJSON(raw []byte) error {
 
 		IdentityID *string `json:"identityId"`
 
+		IPAddress *string `json:"ipAddress"`
+
 		Token *string `json:"token"`
 	}
 	if err := swag.ReadJSON(raw, &dataAO1); err != nil {
@@ -87,6 +93,8 @@ func (m *APISessionDetail) UnmarshalJSON(raw []byte) error {
 	m.Identity = dataAO1.Identity
 
 	m.IdentityID = dataAO1.IdentityID
+
+	m.IPAddress = dataAO1.IPAddress
 
 	m.Token = dataAO1.Token
 
@@ -109,6 +117,8 @@ func (m APISessionDetail) MarshalJSON() ([]byte, error) {
 
 		IdentityID *string `json:"identityId"`
 
+		IPAddress *string `json:"ipAddress"`
+
 		Token *string `json:"token"`
 	}
 
@@ -117,6 +127,8 @@ func (m APISessionDetail) MarshalJSON() ([]byte, error) {
 	dataAO1.Identity = m.Identity
 
 	dataAO1.IdentityID = m.IdentityID
+
+	dataAO1.IPAddress = m.IPAddress
 
 	dataAO1.Token = m.Token
 
@@ -146,6 +158,10 @@ func (m *APISessionDetail) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateIdentityID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIPAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -189,6 +205,15 @@ func (m *APISessionDetail) validateIdentity(formats strfmt.Registry) error {
 func (m *APISessionDetail) validateIdentityID(formats strfmt.Registry) error {
 
 	if err := validate.Required("identityId", "body", m.IdentityID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *APISessionDetail) validateIPAddress(formats strfmt.Registry) error {
+
+	if err := validate.Required("ipAddress", "body", m.IPAddress); err != nil {
 		return err
 	}
 

--- a/rest_server/doc.go
+++ b/rest_server/doc.go
@@ -29,7 +29,7 @@
 //    https
 //  Host: demo.ziti.dev
 //  BasePath: /edge/v1
-//  Version: 0.15.0
+//  Version: 0.16.3
 //  Contact:
 //
 //  Consumes:

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -55,7 +55,7 @@ func init() {
   "info": {
     "title": "Ziti Edge",
     "contact": {},
-    "version": "0.15.0"
+    "version": "0.16.3"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/v1",
@@ -4654,7 +4654,8 @@ func init() {
             "token",
             "identity",
             "identityId",
-            "configTypes"
+            "configTypes",
+            "ipAddress"
           ],
           "properties": {
             "configTypes": {
@@ -4667,6 +4668,9 @@ func init() {
               "$ref": "#/definitions/entityRef"
             },
             "identityId": {
+              "type": "string"
+            },
+            "ipAddress": {
               "type": "string"
             },
             "token": {
@@ -5109,12 +5113,12 @@ func init() {
         }
       },
       "example": {
+        "configTypeId": "cea49285-6c07-42cf-9f52-09a9b115c783",
         "data": {
           "hostname": "example.com",
           "port": 80
         },
-        "name": "test-config",
-        "type": "cea49285-6c07-42cf-9f52-09a9b115c783"
+        "name": "test-config"
       }
     },
     "configDetail": {
@@ -8470,7 +8474,7 @@ func init() {
   "info": {
     "title": "Ziti Edge",
     "contact": {},
-    "version": "0.15.0"
+    "version": "0.16.3"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/v1",
@@ -20452,7 +20456,8 @@ func init() {
             "token",
             "identity",
             "identityId",
-            "configTypes"
+            "configTypes",
+            "ipAddress"
           ],
           "properties": {
             "configTypes": {
@@ -20465,6 +20470,9 @@ func init() {
               "$ref": "#/definitions/entityRef"
             },
             "identityId": {
+              "type": "string"
+            },
+            "ipAddress": {
               "type": "string"
             },
             "token": {
@@ -20907,12 +20915,12 @@ func init() {
         }
       },
       "example": {
+        "configTypeId": "cea49285-6c07-42cf-9f52-09a9b115c783",
         "data": {
           "hostname": "example.com",
           "port": 80
         },
-        "name": "test-config",
-        "type": "cea49285-6c07-42cf-9f52-09a9b115c783"
+        "name": "test-config"
       }
     },
     "configDetail": {

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -1,7 +1,7 @@
 ---
 swagger: '2.0'
 info:
-  version: 0.15.0
+  version: 0.16.3
   title: Ziti Edge
   contact: {}
 host: demo.ziti.dev
@@ -3640,12 +3640,15 @@ definitions:
           - identity
           - identityId
           - configTypes
+          - ipAddress
         properties:
           token:
             type: string
           identity:
             $ref: '#/definitions/entityRef'
           identityId:
+            type: string
+          ipAddress:
             type: string
           configTypes:
             type: array


### PR DESCRIPTION
- adds `http.Request.RemoteAddr` tracking to API sessions in a new field `ipAddress`
- `ipAddress` is IP only,  ipv4 or ipv6
- value can only be set via auth
- updates `swagger.yml` and generated code