### PR TITLE
Fix.305.cert.auth.ca.validation

### DIFF
--- a/controller/model/authenticator_handlers.go
+++ b/controller/model/authenticator_handlers.go
@@ -77,6 +77,7 @@ func (handler AuthenticatorHandler) IsAuthorized(authContext AuthContext) (*Iden
 		return nil, apierror.NewInvalidAuth()
 	}
 
+
 	return handler.env.GetHandlers().Identity.Read(identityId)
 }
 

--- a/controller/model/authenticator_handlers.go
+++ b/controller/model/authenticator_handlers.go
@@ -76,8 +76,7 @@ func (handler AuthenticatorHandler) IsAuthorized(authContext AuthContext) (*Iden
 	if identityId == "" {
 		return nil, apierror.NewInvalidAuth()
 	}
-
-
+	
 	return handler.env.GetHandlers().Identity.Read(identityId)
 }
 

--- a/controller/model/authenticator_handlers.go
+++ b/controller/model/authenticator_handlers.go
@@ -76,7 +76,7 @@ func (handler AuthenticatorHandler) IsAuthorized(authContext AuthContext) (*Iden
 	if identityId == "" {
 		return nil, apierror.NewInvalidAuth()
 	}
-	
+
 	return handler.env.GetHandlers().Identity.Read(identityId)
 }
 

--- a/controller/model/authenticator_mod_cert.go
+++ b/controller/model/authenticator_mod_cert.go
@@ -97,8 +97,6 @@ func (module *AuthModuleCert) Process(context AuthContext) (string, error) {
 
 			if _, err := cert.Verify(opts); err == nil {
 				return authenticator.IdentityId, nil
-			} else {
-				println(err)
 			}
 		}
 	}

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -156,7 +156,7 @@ func (c *Controller) Enabled() bool {
 func (c *Controller) initializeAuthModules() {
 	c.initModulesOnce.Do(func() {
 		c.AppEnv.AuthRegistry.Add(model.NewAuthModuleUpdb(c.AppEnv))
-		c.AppEnv.AuthRegistry.Add(model.NewAuthModuleCert(c.AppEnv))
+		c.AppEnv.AuthRegistry.Add(model.NewAuthModuleCert(c.AppEnv, c.AppEnv.GetConfig().CaPems()))
 
 		c.AppEnv.EnrollRegistry.Add(model.NewEnrollModuleCa(c.AppEnv))
 		c.AppEnv.EnrollRegistry.Add(model.NewEnrollModuleOttCa(c.AppEnv))

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openziti/edge
 
 go 1.14
 
-// replace github.com/openziti/foundation => ../foundation
+//replace github.com/openziti/foundation => ../foundation
 
 //replace github.com/openziti/fabric => ../fabric
 
@@ -35,6 +35,7 @@ require (
 	github.com/openziti/fabric v0.13.6
 	github.com/openziti/foundation v0.14.4
 	github.com/openziti/sdk-golang v0.13.44
+	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/sirupsen/logrus v1.6.0


### PR DESCRIPTION
- cert auth module caches static and dynamic (3rd party) CA chains
- all cert auths validated against active chains
- deleted/disabled 3rd party CAs no longer validate