### PR TITLE
close the server conn when hosting a service and the client closes

### DIFF
--- a/tunnel/intercept/protocols/tcp/proxy.go
+++ b/tunnel/intercept/protocols/tcp/proxy.go
@@ -98,7 +98,7 @@ func Enqueue(context ziti.Context, srcIP, dstIP net.IP, pdu []byte, dev io.ReadW
 				release()
 				return true // this packet is effectively handled here, even though we're dropping it
 			}
-			go tunnel.Run(context, service, clientConn)
+			go tunnel.DialAndRun(context, service, clientConn)
 		} else {
 			log.Debugf("packet from %s lacks TCP syn", clientKey)
 			release()

--- a/tunnel/intercept/proxy/proxy.go
+++ b/tunnel/intercept/proxy/proxy.go
@@ -116,7 +116,7 @@ func (p *interceptor) handleTCP(service *Service) {
 			p.closeCh <- err
 			return
 		}
-		go tunnel.Run(p.context, service.Name, conn)
+		go tunnel.DialAndRun(p.context, service.Name, conn)
 	}
 }
 

--- a/tunnel/intercept/tproxy/tproxy_linux.go
+++ b/tunnel/intercept/tproxy/tproxy_linux.go
@@ -160,7 +160,7 @@ func (t *tProxyInterceptor) accept(context ziti.Context) {
 				client.Close()
 				continue
 			}
-			go tunnel.Run(context, service.Name, client)
+			go tunnel.DialAndRun(context, service.Name, client)
 		}
 	}()
 }

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -26,7 +26,7 @@ import (
 
 var log = logrus.StandardLogger()
 
-func Run(context ziti.Context, service string, clientConn net.Conn) {
+func DialAndRun(context ziti.Context, service string, clientConn net.Conn) {
 	zitiConn, err := context.Dial(service)
 	if err != nil {
 		log.Errorf("zt.Dial(%s) failed: %s", service, err.Error())
@@ -34,6 +34,10 @@ func Run(context ziti.Context, service string, clientConn net.Conn) {
 		return
 	}
 
+	Run(zitiConn, clientConn)
+}
+
+func Run(zitiConn net.Conn, clientConn net.Conn) {
 	loggerFields := logrus.Fields{
 		"src-remote": clientConn.RemoteAddr(), "src-local": clientConn.LocalAddr(),
 		"dst-local": zitiConn.LocalAddr(), "dst-remote": zitiConn.RemoteAddr()}

--- a/tunnel/udp_vconn/manager.go
+++ b/tunnel/udp_vconn/manager.go
@@ -96,7 +96,7 @@ func (manager *manager) CreateWriteQueue(srcAddr net.Addr, service string, write
 	conn.markUsed()
 	manager.connMap[srcAddr.String()] = conn
 	pfxlog.Logger().WithField("udpConnId", srcAddr.String()).Debug("created new virtual UDP connection")
-	go tunnel.Run(manager.context, service, conn)
+	go tunnel.DialAndRun(manager.context, service, conn)
 	return conn, nil
 }
 


### PR DESCRIPTION
Folks have been running into an issue when hosting a service, where the server-side of the tunnel is left open when the client-side closes. This PR fixes the issue by using `tunnel.Run()` to pump hosted service connections.

fixes openziti/ziti#197