### PR TITLE
Narrow json types for list items

### DIFF
--- a/controller/internal/routes/config_api_model.go
+++ b/controller/internal/routes/config_api_model.go
@@ -127,7 +127,7 @@ func MapConfigToRestModel(ae *env.AppEnv, config *model.Config) (*rest_model.Con
 
 func narrowJsonTypesList(l []interface{}) {
 	for i, v := range l {
-		if parsedNumber, ok := (v).(ParsedNumber); ok {
+		if parsedNumber, ok := v.(ParsedNumber); ok {
 			//floats don't parse as int, try int first, then float, else give up
 			if intVal, err := parsedNumber.Int64(); err == nil {
 				v = intVal
@@ -154,7 +154,7 @@ func narrowJsonTypesList(l []interface{}) {
 
 func narrowJsonTypesMap(m map[string]interface{}) {
 	for k, v := range m {
-		if parsedNumber, ok := (v).(ParsedNumber); ok {
+		if parsedNumber, ok := v.(ParsedNumber); ok {
 			//floats don't parse as int, try int first, then float, else give up
 			if intVal, err := parsedNumber.Int64(); err == nil {
 				v = intVal

--- a/controller/internal/routes/config_api_model.go
+++ b/controller/internal/routes/config_api_model.go
@@ -125,28 +125,25 @@ func MapConfigToRestModel(ae *env.AppEnv, config *model.Config) (*rest_model.Con
 	return ret, nil
 }
 
-func narrowJsonType(v *interface{}) {
-	if parsedNumber, ok := (*v).(ParsedNumber); ok {
-		//floats don't parse as int, try int first, then float, else give up
-		if intVal, err := parsedNumber.Int64(); err == nil {
-			*v = intVal
-		} else if floatVal, err := parsedNumber.Float64(); err == nil {
-			*v = floatVal
-			intVal := math.Trunc(floatVal)
-			if intVal == floatVal {
-				*v = intVal
-			}
-		}
-	}
-}
-
 func narrowJsonTypesList(l []interface{}) {
 	for i, v := range l {
-		narrowJsonType(&v)
+		if parsedNumber, ok := (v).(ParsedNumber); ok {
+			//floats don't parse as int, try int first, then float, else give up
+			if intVal, err := parsedNumber.Int64(); err == nil {
+				v = intVal
+				l[i] = intVal
+			} else if floatVal, err := parsedNumber.Float64(); err == nil {
+				v = floatVal
+				l[i] = floatVal
+			}
+		}
 
 		switch val := v.(type) {
-		case int64, float64:
-			l[i] = v
+		case float64:
+			intVal := math.Trunc(val)
+			if intVal == val {
+				l[i] = intVal
+			}
 		case []interface{}:
 			narrowJsonTypesList(val)
 		case map[string]interface{}:
@@ -157,11 +154,23 @@ func narrowJsonTypesList(l []interface{}) {
 
 func narrowJsonTypesMap(m map[string]interface{}) {
 	for k, v := range m {
-		narrowJsonType(&v)
+		if parsedNumber, ok := (v).(ParsedNumber); ok {
+			//floats don't parse as int, try int first, then float, else give up
+			if intVal, err := parsedNumber.Int64(); err == nil {
+				v = intVal
+				m[k] = intVal
+			} else if floatVal, err := parsedNumber.Float64(); err == nil {
+				v = floatVal
+				m[k] = floatVal
+			}
+		}
 
 		switch val := v.(type) {
-		case int64, float64:
-			m[k] = v
+		case float64:
+			intVal := math.Trunc(val)
+			if intVal == val {
+				m[k] = intVal
+			}
 		case []interface{}:
 			narrowJsonTypesList(val)
 		case map[string]interface{}:

--- a/controller/internal/routes/config_api_model.go
+++ b/controller/internal/routes/config_api_model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openziti/edge/rest_model"
 	"github.com/openziti/fabric/controller/models"
 	"github.com/openziti/foundation/util/stringz"
+	"math"
 )
 
 const EntityNameConfig = "configs"
@@ -131,6 +132,10 @@ func resolveParsedNumber(v interface{}) interface{} {
 			v = intVal
 		} else if floatVal, err := parsedNumber.Float64(); err == nil {
 			v = floatVal
+			intVal := math.Trunc(floatVal)
+			if intVal == floatVal {
+				v = intVal
+			}
 		}
 	}
 	return v


### PR DESCRIPTION
Attempts to create a service configuration with a list of numbers would fail with `unsupported type json.Number in map`. this PR narrows the json types for lists.