### PR TITLE
Add.online.status

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -280,11 +280,11 @@ func NewAppEnv(c *edgeConfig.Config) *AppEnv {
 			Api:           "1.0.0",
 			EnrollmentApi: "1.0.0",
 		},
-		AuthCookieName: constants.ZitiSession,
-		AuthHeaderName: constants.ZitiSession,
-		AuthRegistry:   &model.AuthProcessorRegistryImpl{},
-		EnrollRegistry: &model.EnrollmentRegistryImpl{},
-		Api:            api,
+		AuthCookieName:    constants.ZitiSession,
+		AuthHeaderName:    constants.ZitiSession,
+		AuthRegistry:      &model.AuthProcessorRegistryImpl{},
+		EnrollRegistry:    &model.EnrollmentRegistryImpl{},
+		Api:               api,
 	}
 
 	api.APIAuthorizer = authorizer{}

--- a/controller/internal/routes/identity_api_model.go
+++ b/controller/internal/routes/identity_api_model.go
@@ -160,14 +160,18 @@ func MapIdentityToRestModel(ae *env.AppEnv, identity *model.Identity) (*rest_mod
 		return nil, err
 	}
 
+	hasApiSession := identity.ApiSessionCount > 0
+
 	ret := &rest_model.IdentityDetail{
-		BaseEntity:     BaseEntityToRestModel(identity, IdentityLinkFactory),
-		IsAdmin:        &identity.IsAdmin,
-		IsDefaultAdmin: &identity.IsDefaultAdmin,
-		Name:           &identity.Name,
-		RoleAttributes: identity.RoleAttributes,
-		Type:           ToEntityRef(identityType.Name, identityType, IdentityTypeLinkFactory),
-		TypeID:         &identityType.Id,
+		BaseEntity:              BaseEntityToRestModel(identity, IdentityLinkFactory),
+		IsAdmin:                 &identity.IsAdmin,
+		IsDefaultAdmin:          &identity.IsDefaultAdmin,
+		Name:                    &identity.Name,
+		RoleAttributes:          identity.RoleAttributes,
+		Type:                    ToEntityRef(identityType.Name, identityType, IdentityTypeLinkFactory),
+		TypeID:                  &identityType.Id,
+		HasEdgeRouterConnection: &identity.HasHeartbeat,
+		HasAPISession:           &hasApiSession,
 	}
 	fillInfo(ret, identity.EnvInfo, identity.SdkInfo)
 
@@ -305,10 +309,10 @@ func GetNamedIdentityRoles(identityHandler *model.IdentityHandler, roles []strin
 			}
 
 			result = append(result, &rest_model.NamedRole{
-				Role:   role,
+				Role: role,
 				Name: "@" + identity.Name,
 			})
-		}else {
+		} else {
 			result = append(result, &rest_model.NamedRole{
 				Role: role,
 				Name: role,

--- a/controller/persistence/api_session_store.go
+++ b/controller/persistence/api_session_store.go
@@ -72,7 +72,6 @@ type ApiSessionStore interface {
 	LoadOneByToken(tx *bbolt.Tx, token string) (*ApiSession, error)
 	LoadOneByQuery(tx *bbolt.Tx, query string) (*ApiSession, error)
 	GetTokenIndex() boltz.ReadIndex
-	MarkActivity(tx *bbolt.Tx, tokens []string) error
 }
 
 func newApiSessionStore(stores *stores) *apiSessionStoreImpl {
@@ -132,18 +131,4 @@ func (store *apiSessionStoreImpl) LoadOneByQuery(tx *bbolt.Tx, query string) (*A
 		return nil, err
 	}
 	return entity, nil
-}
-
-func (store *apiSessionStoreImpl) MarkActivity(tx *bbolt.Tx, tokens []string) error {
-	mutCtx := boltz.NewMutateContext(tx)
-	for _, token := range tokens {
-		apiSession, err := store.LoadOneByToken(tx, token)
-		if err != nil {
-			return err
-		}
-		if err = store.Update(mutCtx, apiSession, UpdateTimeOnlyFieldChecker{}); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/controller/persistence/identity_store.go
+++ b/controller/persistence/identity_store.go
@@ -91,7 +91,7 @@ type ServiceConfig struct {
 
 var identityFieldMappings = map[string]string{FieldIdentityType: "identityTypeId"}
 
-func (entity *Identity) LoadValues(_ boltz.CrudStore, bucket *boltz.TypedBucket) {
+func (entity *Identity) LoadValues(store boltz.CrudStore, bucket *boltz.TypedBucket) {
 	entity.LoadBaseValues(bucket)
 	entity.Name = bucket.GetStringOrError(FieldName)
 	entity.IdentityTypeId = bucket.GetStringWithDefault(FieldIdentityType, "")
@@ -271,6 +271,7 @@ func (store *identityStoreImpl) LoadOneById(tx *bbolt.Tx, id string) (*Identity,
 	if err := store.baseLoadOneById(tx, id, entity); err != nil {
 		return nil, err
 	}
+
 	return entity, nil
 }
 

--- a/rest_model/identity_detail.go
+++ b/rest_model/identity_detail.go
@@ -54,6 +54,14 @@ type IdentityDetail struct {
 	// Required: true
 	EnvInfo *EnvInfo `json:"envInfo"`
 
+	// has Api session
+	// Required: true
+	HasAPISession *bool `json:"hasApiSession"`
+
+	// has edge router connection
+	// Required: true
+	HasEdgeRouterConnection *bool `json:"hasEdgeRouterConnection"`
+
 	// is admin
 	// Required: true
 	IsAdmin *bool `json:"isAdmin"`
@@ -100,6 +108,10 @@ func (m *IdentityDetail) UnmarshalJSON(raw []byte) error {
 
 		EnvInfo *EnvInfo `json:"envInfo"`
 
+		HasAPISession *bool `json:"hasApiSession"`
+
+		HasEdgeRouterConnection *bool `json:"hasEdgeRouterConnection"`
+
 		IsAdmin *bool `json:"isAdmin"`
 
 		IsDefaultAdmin *bool `json:"isDefaultAdmin"`
@@ -123,6 +135,10 @@ func (m *IdentityDetail) UnmarshalJSON(raw []byte) error {
 	m.Enrollment = dataAO1.Enrollment
 
 	m.EnvInfo = dataAO1.EnvInfo
+
+	m.HasAPISession = dataAO1.HasAPISession
+
+	m.HasEdgeRouterConnection = dataAO1.HasEdgeRouterConnection
 
 	m.IsAdmin = dataAO1.IsAdmin
 
@@ -157,6 +173,10 @@ func (m IdentityDetail) MarshalJSON() ([]byte, error) {
 
 		EnvInfo *EnvInfo `json:"envInfo"`
 
+		HasAPISession *bool `json:"hasApiSession"`
+
+		HasEdgeRouterConnection *bool `json:"hasEdgeRouterConnection"`
+
 		IsAdmin *bool `json:"isAdmin"`
 
 		IsDefaultAdmin *bool `json:"isDefaultAdmin"`
@@ -177,6 +197,10 @@ func (m IdentityDetail) MarshalJSON() ([]byte, error) {
 	dataAO1.Enrollment = m.Enrollment
 
 	dataAO1.EnvInfo = m.EnvInfo
+
+	dataAO1.HasAPISession = m.HasAPISession
+
+	dataAO1.HasEdgeRouterConnection = m.HasEdgeRouterConnection
 
 	dataAO1.IsAdmin = m.IsAdmin
 
@@ -218,6 +242,14 @@ func (m *IdentityDetail) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateEnvInfo(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateHasAPISession(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateHasEdgeRouterConnection(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -304,6 +336,24 @@ func (m *IdentityDetail) validateEnvInfo(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *IdentityDetail) validateHasAPISession(formats strfmt.Registry) error {
+
+	if err := validate.Required("hasApiSession", "body", m.HasAPISession); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *IdentityDetail) validateHasEdgeRouterConnection(formats strfmt.Registry) error {
+
+	if err := validate.Required("hasEdgeRouterConnection", "body", m.HasEdgeRouterConnection); err != nil {
+		return err
 	}
 
 	return nil

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -7103,7 +7103,9 @@ func init() {
             "enrollment",
             "envInfo",
             "sdkInfo",
-            "roleAttributes"
+            "roleAttributes",
+            "hasEdgeRouterConnection",
+            "hasApiSession"
           ],
           "properties": {
             "authenticators": {
@@ -7114,6 +7116,12 @@ func init() {
             },
             "envInfo": {
               "$ref": "#/definitions/envInfo"
+            },
+            "hasApiSession": {
+              "type": "boolean"
+            },
+            "hasEdgeRouterConnection": {
+              "type": "boolean"
             },
             "isAdmin": {
               "type": "boolean"
@@ -24429,7 +24437,9 @@ func init() {
             "enrollment",
             "envInfo",
             "sdkInfo",
-            "roleAttributes"
+            "roleAttributes",
+            "hasEdgeRouterConnection",
+            "hasApiSession"
           ],
           "properties": {
             "authenticators": {
@@ -24440,6 +24450,12 @@ func init() {
             },
             "envInfo": {
               "$ref": "#/definitions/envInfo"
+            },
+            "hasApiSession": {
+              "type": "boolean"
+            },
+            "hasEdgeRouterConnection": {
+              "type": "boolean"
             },
             "isAdmin": {
               "type": "boolean"

--- a/router/internal/router/config.go
+++ b/router/internal/router/config.go
@@ -19,6 +19,7 @@ package router
 import (
 	"errors"
 	"fmt"
+	"github.com/michaelquigley/pfxlog"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openziti/foundation/identity/identity"
 	"github.com/openziti/foundation/transport"
@@ -26,6 +27,12 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+)
+
+const (
+	DefaultHeartbeatIntervalSeconds = 60
+	MinHeartbeatIntervalSeconds     = 10
+	MaxHeartbeatIntervalSeconds     = 60
 )
 
 type Config struct {
@@ -102,8 +109,9 @@ func (config *Config) LoadConfigFromMap(configMap map[interface{}]interface{}) e
 		config.HeartbeatIntervalSeconds = val.(int)
 	}
 
-	if config.HeartbeatIntervalSeconds == 0 {
-		config.HeartbeatIntervalSeconds = 60
+	if config.HeartbeatIntervalSeconds > DefaultHeartbeatIntervalSeconds || config.HeartbeatIntervalSeconds <= MinHeartbeatIntervalSeconds {
+		pfxlog.Logger().Warnf("Invalid heartbeat interval [%v] (min: %v, max: %v), setting to default [%v]", config.HeartbeatIntervalSeconds, MaxHeartbeatIntervalSeconds, MinHeartbeatIntervalSeconds, DefaultHeartbeatIntervalSeconds)
+		config.HeartbeatIntervalSeconds = DefaultHeartbeatIntervalSeconds
 	}
 
 	if err = config.loadApiProxy(edgeConfigMap); err != nil {

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -4052,6 +4052,8 @@ definitions:
           - envInfo
           - sdkInfo
           - roleAttributes
+          - hasEdgeRouterConnection
+          - hasApiSession
         properties:
           name:
             type: string
@@ -4073,6 +4075,10 @@ definitions:
             $ref: '#/definitions/sdkInfo'
           roleAttributes:
             $ref: '#/definitions/attributes'
+          hasEdgeRouterConnection:
+            type: boolean
+          hasApiSession:
+            type: boolean
   identityAuthenticators:
     type: object
     properties:


### PR DESCRIPTION
Adds two bool properties `hasEdgeRouterConnection` and `hasApiSession` to each identity.

- `hasEdgeRouterConnetion` has a status resolution of 60s (the max heartbeat interval routers will use)
- `hasApiSession` has a resolution based upon the session timeout 

```
{
    "data": {
        "_links": {
            "edge-router-policies": {
                "href": "./identities/3ao0MGtMg/edge-routers"
            },
            "self": {
                "href": "./identities/3ao0MGtMg"
            }
        },
        "createdAt": "2020-10-19T21:29:09.502Z",
        "id": "3ao0MGtMg",
        "tags": {},
        "updatedAt": "2020-10-20T18:34:06.556Z",
        "authenticators": {
            "cert": {
                "fingerprint": "c5ba5fe6e79a4fbea60682ab7099b4bf7cccd7ce"
            }
        },
        "enrollment": {},
        "envInfo": {
            "arch": "amd64",
            "os": "windows",
            "osRelease": "6.2.9200",
            "osVersion": "6.2.9200"
        },
        "hasApiSession": true,
        "hasEdgeRouterConnection": false,
        "isAdmin": false,
        "isDefaultAdmin": false,
        "name": "proxy",
        "roleAttributes": null,
        "sdkInfo": {
            "branch": "master",
            "revision": "a8baa9923e52",
            "type": "ziti-sdk-golang",
            "version": "v0.9.0"
        },
        "type": {
            "_links": {
                "self": {
                    "href": "./identity-types/c4d66f9d-fe18-4143-85d3-74329c54282b"
                }
            },
            "entity": "identity-types",
            "id": "c4d66f9d-fe18-4143-85d3-74329c54282b",
            "name": "Service"
        },
        "typeId": "c4d66f9d-fe18-4143-85d3-74329c54282b"
    },
    "meta": null
}
```