### PR TITLE
fixes #372 ensures v13 dbs have posture check types

### DIFF
--- a/controller/persistence/migration_initialize.go
+++ b/controller/persistence/migration_initialize.go
@@ -34,6 +34,7 @@ func (m *Migrations) initialize(step *boltz.MigrationStep) int {
 	m.createGeoRegionsV1(step)
 	m.createIdentityTypesV1(step)
 	m.createInitialTunnelerConfigTypes(step)
+	m.addPostureCheckTypes(step)
 
 	return CurrentDbVersion
 }

--- a/controller/persistence/migration_v12.go
+++ b/controller/persistence/migration_v12.go
@@ -1,11 +1,23 @@
 package persistence
 
 import (
+	"fmt"
 	"github.com/openziti/foundation/storage/boltz"
 	"time"
 )
 
 func (m *Migrations) addPostureCheckTypes(step *boltz.MigrationStep) {
+
+	_, count, err := m.stores.PostureCheckType.QueryIds(step.Ctx.Tx(), "true limit 500")
+
+	if err != nil {
+		step.SetError(fmt.Errorf("could not query posture check types: %v", err))
+	}
+
+	if count > 0 {
+		return //already added
+	}
+
 	windows := OperatingSystem{
 		OsType:     "Windows",
 		OsVersions: []string{"Vista", "7", "8", "10", "2000"},

--- a/controller/persistence/migrations.go
+++ b/controller/persistence/migrations.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	CurrentDbVersion = 12
+	CurrentDbVersion = 13
 	FieldVersion     = "version"
 )
 
@@ -103,6 +103,11 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 	}
 
 	if step.CurrentVersion < 12 {
+		m.addPostureCheckTypes(step)
+	}
+
+	if step.CurrentVersion < 13 {
+		//do again because in v12 the init wasn't run so some instances at v12 don't have posture check types
 		m.addPostureCheckTypes(step)
 	}
 


### PR DESCRIPTION
- adds posture check types to init
- on v12/v13 migrations, posture check types are checked and added if
  necessary