### PR TITLE
fixes #394

### DIFF
--- a/controller/model/posture_check_model_process.go
+++ b/controller/model/posture_check_model_process.go
@@ -37,6 +37,10 @@ func (p *PostureCheckProcess) Evaluate(pd *PostureData) bool {
 				return false
 			}
 
+			if !process.IsRunning {
+				return false
+			}
+
 			if p.Fingerprint != "" {
 				if p.Fingerprint != process.SignerFingerprint {
 					return false

--- a/controller/model/posture_response_handlers.go
+++ b/controller/model/posture_response_handlers.go
@@ -86,22 +86,26 @@ func (handler *PostureResponseHandler) postureDataUpdated(identityId string) {
 					validServices[session.ServiceId] = false
 					checkMap := handler.env.GetHandlers().EdgeService.GetPostureChecks(identityId, session.ServiceId)
 
-					for policyId, checks := range checkMap {
-						isValidPolicy, isEvaluatedPolicy := validPolicies[policyId]
+					if len(checkMap) == 0 {
+						isValidService = true
+					} else {
+						for policyId, checks := range checkMap {
+							isValidPolicy, isEvaluatedPolicy := validPolicies[policyId]
 
-						if !isEvaluatedPolicy { //not checked yet
-							validPolicies[policyId] = false
-							isValidPolicy = false
-							if handler.postureCache.Evaluate(identityId, checks) {
-								isValidService = true
-								isValidPolicy = true
+							if !isEvaluatedPolicy { //not checked yet
+								validPolicies[policyId] = false
+								isValidPolicy = false
+								if handler.postureCache.Evaluate(identityId, checks) {
+									isValidService = true
+									isValidPolicy = true
+								}
 							}
-						}
 
-						validPolicies[policyId] = isValidPolicy
+							validPolicies[policyId] = isValidPolicy
 
-						if isValidPolicy {
-							break //found 1 valid policy, stop
+							if isValidPolicy {
+								break //found 1 valid policy, stop
+							}
 						}
 					}
 


### PR DESCRIPTION
In scenarios where a service has no policies with any checks after
initialization, the posture checks would fail incorrectly.