### PR TITLE
Send.all.signers

### DIFF
--- a/controller/internal/routes/posture_response_router.go
+++ b/controller/internal/routes/posture_response_router.go
@@ -103,7 +103,7 @@ func (r *PostureResponseRouter) Create(ae *env.AppEnv, rc *response.RequestConte
 			subType := &model.PostureResponseProcess{
 				IsRunning:         apiPostureResponse.IsRunning,
 				BinaryHash:        apiPostureResponse.Hash,
-				SignerFingerprint: apiPostureResponse.SignerFingerprint,
+				SignerFingerprints: apiPostureResponse.SignerFingerprints,
 			}
 
 			subType.PostureResponse = postureResponse

--- a/controller/model/posture_check_model_process.go
+++ b/controller/model/posture_check_model_process.go
@@ -43,7 +43,16 @@ func (p *PostureCheckProcess) Evaluate(pd *PostureData) bool {
 			}
 
 			if p.Fingerprint != "" {
-				if !strings.EqualFold(p.Fingerprint, process.SignerFingerprint) {
+				isFingerprintValid := false
+
+				for _, fingerprint := range process.SignerFingerprints {
+					if strings.EqualFold(p.Fingerprint, fingerprint) {
+						isFingerprintValid = true
+						break
+					}
+				}
+
+				if !isFingerprintValid {
 					return false
 				}
 			}

--- a/controller/model/posture_response_model.go
+++ b/controller/model/posture_response_model.go
@@ -225,15 +225,18 @@ func (pr *PostureResponseOs) Apply(postureData *PostureData) {
 
 type PostureResponseProcess struct {
 	*PostureResponse
-	IsRunning         bool   `json:"isRunning"`
-	BinaryHash        string `json:"binaryHash"`
-	SignerFingerprint string `json:"signerFingerprint"`
+	IsRunning          bool     `json:"isRunning"`
+	BinaryHash         string   `json:"binaryHash"`
+	SignerFingerprints []string `json:"signerFingerprints"`
 }
 
 func (pr *PostureResponseProcess) Apply(postureData *PostureData) {
 	found := false
 
-	pr.SignerFingerprint = CleanHexString(pr.SignerFingerprint)
+	for i, fingerprint := range pr.SignerFingerprints {
+		pr.SignerFingerprints[i] = CleanHexString(fingerprint)
+	}
+	
 	pr.BinaryHash = CleanHexString(pr.BinaryHash)
 
 	for i, process := range postureData.Processes {

--- a/controller/persistence/posture_check_process.go
+++ b/controller/persistence/posture_check_process.go
@@ -18,6 +18,7 @@ package persistence
 
 import (
 	"github.com/openziti/foundation/storage/boltz"
+	"strings"
 )
 
 const (
@@ -51,6 +52,13 @@ func (entity *PostureCheckProcess) LoadValues(_ boltz.CrudStore, bucket *boltz.T
 }
 
 func (entity *PostureCheckProcess) SetValues(ctx *boltz.PersistContext, bucket *boltz.TypedBucket) {
+
+	entity.Fingerprint = strings.ToLower(entity.Fingerprint)
+
+	for i, hash := range entity.Hashes {
+		entity.Hashes[i] = strings.ToLower(hash)
+	}
+
 	bucket.SetString(FieldPostureCheckProcessOs, entity.OperatingSystem, ctx.FieldChecker)
 	bucket.SetString(FieldPostureCheckProcessPath, entity.Path, ctx.FieldChecker)
 	bucket.SetStringList(FieldPostureCheckProcessHashes, entity.Hashes, ctx.FieldChecker)

--- a/controller/persistence/posture_check_process.go
+++ b/controller/persistence/posture_check_process.go
@@ -18,7 +18,6 @@ package persistence
 
 import (
 	"github.com/openziti/foundation/storage/boltz"
-	"strings"
 )
 
 const (
@@ -52,13 +51,6 @@ func (entity *PostureCheckProcess) LoadValues(_ boltz.CrudStore, bucket *boltz.T
 }
 
 func (entity *PostureCheckProcess) SetValues(ctx *boltz.PersistContext, bucket *boltz.TypedBucket) {
-
-	entity.Fingerprint = strings.ToLower(entity.Fingerprint)
-
-	for i, hash := range entity.Hashes {
-		entity.Hashes[i] = strings.ToLower(hash)
-	}
-
 	bucket.SetString(FieldPostureCheckProcessOs, entity.OperatingSystem, ctx.FieldChecker)
 	bucket.SetString(FieldPostureCheckProcessPath, entity.Path, ctx.FieldChecker)
 	bucket.SetStringList(FieldPostureCheckProcessHashes, entity.Hashes, ctx.FieldChecker)

--- a/rest_model/posture_response_process_create.go
+++ b/rest_model/posture_response_process_create.go
@@ -51,8 +51,8 @@ type PostureResponseProcessCreate struct {
 	// is running
 	IsRunning bool `json:"isRunning,omitempty"`
 
-	// signer fingerprint
-	SignerFingerprint string `json:"signerFingerprint,omitempty"`
+	// signer fingerprints
+	SignerFingerprints []string `json:"signerFingerprints"`
 }
 
 // ID gets the id of this subtype
@@ -84,8 +84,8 @@ func (m *PostureResponseProcessCreate) UnmarshalJSON(raw []byte) error {
 		// is running
 		IsRunning bool `json:"isRunning,omitempty"`
 
-		// signer fingerprint
-		SignerFingerprint string `json:"signerFingerprint,omitempty"`
+		// signer fingerprints
+		SignerFingerprints []string `json:"signerFingerprints"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -121,7 +121,7 @@ func (m *PostureResponseProcessCreate) UnmarshalJSON(raw []byte) error {
 
 	result.Hash = data.Hash
 	result.IsRunning = data.IsRunning
-	result.SignerFingerprint = data.SignerFingerprint
+	result.SignerFingerprints = data.SignerFingerprints
 
 	*m = result
 
@@ -140,15 +140,15 @@ func (m PostureResponseProcessCreate) MarshalJSON() ([]byte, error) {
 		// is running
 		IsRunning bool `json:"isRunning,omitempty"`
 
-		// signer fingerprint
-		SignerFingerprint string `json:"signerFingerprint,omitempty"`
+		// signer fingerprints
+		SignerFingerprints []string `json:"signerFingerprints"`
 	}{
 
 		Hash: m.Hash,
 
 		IsRunning: m.IsRunning,
 
-		SignerFingerprint: m.SignerFingerprint,
+		SignerFingerprints: m.SignerFingerprints,
 	})
 	if err != nil {
 		return nil, err

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -5515,8 +5515,11 @@ func init() {
             "isRunning": {
               "type": "boolean"
             },
-            "signerFingerprint": {
-              "type": "string"
+            "signerFingerprints": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -23186,8 +23189,11 @@ func init() {
             "isRunning": {
               "type": "boolean"
             },
-            "signerFingerprint": {
-              "type": "string"
+            "signerFingerprints": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -6633,6 +6633,8 @@ definitions:
             type: boolean
           hash:
             type: string
-          signerFingerprint:
-            type: string
+          signerFingerprints:
+            type: array
+            items:
+              type: string
     x-class: "PROCESS"


### PR DESCRIPTION
Process posture responses now allow an array of digital signer fingerprints to be submitted and checked. This is so digital certs that are not in leaf-leading order can still pass.