### PR TITLE
use custom alphabet for id generation

### DIFF
--- a/eid/id.go
+++ b/eid/id.go
@@ -2,9 +2,18 @@ package eid
 
 import (
 	"github.com/teris-io/shortid"
+	"math/rand"
 )
 
+const Alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-"
+
+var idGenerator *shortid.Shortid
+
+func init() {
+	idGenerator = shortid.MustNew(0, Alphabet, rand.Uint64())
+}
+
 func New() string {
-	id, _ := shortid.GetDefault().Generate()
+	id, _ := idGenerator.Generate()
 	return id
 }


### PR DESCRIPTION
Using underscores causes issues with common name fields as they cannot
have underscores.