### PR TITLE
add configurable http timeouts

### DIFF
--- a/controller/server/api_server.go
+++ b/controller/server/api_server.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"time"
 )
 
 type apiServer struct {
@@ -39,18 +38,20 @@ func newApiServer(c *config.Config, r http.Handler) *apiServer {
 	logWriter := pfxlog.Logger().Writer()
 
 	tlsConfig := c.Api.Identity.ServerTLSConfig()
+
 	tlsConfig.ClientAuth = tls.RequestClientCert
 
 	return &apiServer{
 		logWriter: logWriter,
 		httpServer: &http.Server{
-			Addr:         c.Api.Listener,
-			WriteTimeout: time.Second * 10,
-			ReadTimeout:  time.Second * 5,
-			IdleTimeout:  time.Second * 5,
-			Handler:      r,
-			TLSConfig:    tlsConfig,
-			ErrorLog:     log.New(logWriter, "", 0),
+			Addr:              c.Api.Listener,
+			WriteTimeout:      c.Api.HttpTimeouts.WriteTimeoutDuration,
+			ReadTimeout:       c.Api.HttpTimeouts.ReadTimeoutDuration,
+			ReadHeaderTimeout: c.Api.HttpTimeouts.ReadHeaderTimeoutDuration,
+			IdleTimeout:       c.Api.HttpTimeouts.IdleTimeoutsDuration,
+			Handler:           r,
+			TLSConfig:         tlsConfig,
+			ErrorLog:          log.New(logWriter, "", 0),
 		},
 	}
 }


### PR DESCRIPTION
Config adds:

```
edge:
  api:
    # (optional, see individual fields for defaults) Sets Edge API HTTP timeout values
    httpTimeouts:
      # (optional, default 5s) readTimeoutMs is the maximum duration for reading the entire request, including the body.
      readTimeoutMs: 5000
      # (optional, default 0) readHeaderTimeoutMs is the amount of time allowed to read request headers.
      # The connection's read deadline is reset after reading the headers. If readHeaderTimeoutMs is zero, the value of
      # readTimeoutMs is used. If both are zero, there is no timeout.
      readHeaderTimeoutMs: 0
      # (optional, default 10000) writeTimeoutMs is the maximum duration before timing out writes of the response.
      writeTimeoutMs: 100000
      # (optional, default 5000) idleTimeoutMs is the maximum amount of time to wait for the next request when keep-alives are enabled
      idleTimeoutMs: 5000
```
