### PR TITLE
moves hasApiSession lookup to api model and limit 1

### DIFF
--- a/controller/internal/routes/identity_api_model.go
+++ b/controller/internal/routes/identity_api_model.go
@@ -179,7 +179,13 @@ func MapIdentityToRestModel(ae *env.AppEnv, identity *model.Identity) (*rest_mod
 
 	isMfaEnabled := mfa != nil && mfa.IsVerified
 
-	hasApiSession := identity.ApiSessionCount > 0
+	hasApiSession := false
+
+	if apiSessionlist, err := ae.GetHandlers().ApiSession.Query(fmt.Sprintf(`identity = "%s" limit 1`, identity.Id)); err == nil {
+		hasApiSession = apiSessionlist.Count > 0
+	} else {
+		pfxlog.Logger().Error("error attempting to determine identity id's [%s] API session existence: %v", identity.Id, err)
+	}
 
 	defaultCost := rest_model.TerminatorCost(identity.DefaultHostingCost)
 
@@ -195,7 +201,7 @@ func MapIdentityToRestModel(ae *env.AppEnv, identity *model.Identity) (*rest_mod
 		HasAPISession:            &hasApiSession,
 		DefaultHostingPrecedence: rest_model.TerminatorPrecedence(identity.DefaultHostingPrecedence.String()),
 		DefaultHostingCost:       &defaultCost,
-		IsMfaEnabled:            &isMfaEnabled,
+		IsMfaEnabled:             &isMfaEnabled,
 	}
 	fillInfo(ret, identity.EnvInfo, identity.SdkInfo)
 

--- a/controller/internal/routes/identity_api_model.go
+++ b/controller/internal/routes/identity_api_model.go
@@ -181,10 +181,10 @@ func MapIdentityToRestModel(ae *env.AppEnv, identity *model.Identity) (*rest_mod
 
 	hasApiSession := false
 
-	if apiSessionlist, err := ae.GetHandlers().ApiSession.Query(fmt.Sprintf(`identity = "%s" limit 1`, identity.Id)); err == nil {
-		hasApiSession = apiSessionlist.Count > 0
+	if apiSessionList, err := ae.GetHandlers().ApiSession.Query(fmt.Sprintf(`identity = "%s" limit 1`, identity.Id)); err == nil {
+		hasApiSession = apiSessionList.Count > 0
 	} else {
-		pfxlog.Logger().Error("error attempting to determine identity id's [%s] API session existence: %v", identity.Id, err)
+		pfxlog.Logger().Errorf("error attempting to determine identity id's [%s] API session existence: %v", identity.Id, err)
 	}
 
 	defaultCost := rest_model.TerminatorCost(identity.DefaultHostingCost)

--- a/controller/model/identity_model.go
+++ b/controller/model/identity_model.go
@@ -17,7 +17,6 @@
 package model
 
 import (
-	"fmt"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/fabric/controller/models"
 	"github.com/openziti/foundation/storage/boltz"
@@ -53,7 +52,6 @@ type Identity struct {
 	EnvInfo                  *EnvInfo
 	SdkInfo                  *SdkInfo
 	HasHeartbeat             bool
-	ApiSessionCount          int64
 	DefaultHostingPrecedence ziti.Precedence
 	DefaultHostingCost       uint16
 }
@@ -173,14 +171,6 @@ func (entity *Identity) fillFrom(handler Handler, tx *bbolt.Tx, boltEntity boltz
 	entity.DefaultHostingCost = boltIdentity.DefaultHostingCost
 
 	fillModelInfo(entity, boltIdentity.EnvInfo, boltIdentity.SdkInfo)
-
-	_, sessionCount, err := handler.GetEnv().GetStores().ApiSession.QueryIds(tx, fmt.Sprintf(`identity = "%s"`, entity.Id))
-
-	if err != nil {
-		return err
-	}
-
-	entity.ApiSessionCount = sessionCount
 
 	return nil
 }


### PR DESCRIPTION
This move isolates the cost of hasApiSession to the identity endpoint lookups in the REST API. Being in the model caused this cost to be shared on all identity lookups for internal logic.

Limit 1 is an attempt to reduce the cost of searching over a large set.

Also added tests.