### PR TITLE
fixes os PATCH for posture checks

### DIFF
--- a/tests/current_identity_test.go
+++ b/tests/current_identity_test.go
@@ -47,7 +47,7 @@ func Test_CurrentIdentity(t *testing.T) {
 			erArray[0].ExistsP("id")
 		})
 
-		t.Run("returns empty list with if edge routter is deleted", func(t *testing.T) {
+		t.Run("returns empty list with if edge router is deleted", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
 			ctx.AdminSession.requireDeleteEntity(er1)


### PR DESCRIPTION
PATCH requests were clearing OS fields as they were not respecting field
checker results.