### PR TITLE
ignore duplicate connecting routers, do not dereference er hostnames

### DIFF
--- a/controller/env/broker.go
+++ b/controller/env/broker.go
@@ -73,8 +73,9 @@ func NewBroker(ae *AppEnv, synchronizer RouterSyncStrategy) *Broker {
 
 func (broker *Broker) RouterConnected(router *network.Router) {
 	go func() {
-		log := pfxlog.Logger().WithField("routerId", router.Id).WithField("routerName", router.Name).WithField("routerFingerprint", router.Fingerprint)
-		if router.Fingerprint != nil {
+		//check connection status, if already connected, ignore as it will be disconnected shortly
+		if router.Fingerprint != nil && !broker.ae.HostController.GetNetwork().ConnectedRouter(router.Id) {
+			log := pfxlog.Logger().WithField("routerId", router.Id).WithField("routerName", router.Name).WithField("routerFingerprint", router.Fingerprint)
 			if edgeRouter, _ := broker.ae.Handlers.EdgeRouter.ReadOneByFingerprint(*router.Fingerprint); edgeRouter != nil {
 				pfxlog.Logger().WithField("routerId", router.Id).
 					WithField("routerName", router.Name).

--- a/controller/internal/routes/edge_router_api_model.go
+++ b/controller/internal/routes/edge_router_api_model.go
@@ -111,7 +111,7 @@ func MapEdgeRouterToRestEntity(ae *env.AppEnv, _ *response.RequestContext, e mod
 }
 
 func MapEdgeRouterToRestModel(ae *env.AppEnv, router *model.EdgeRouter) (*rest_model.EdgeRouterDetail, error) {
-	hostname := ""
+	var hostname *string
 	protocols := map[string]string{}
 	os := ""
 	arch := ""
@@ -125,7 +125,7 @@ func MapEdgeRouterToRestModel(ae *env.AppEnv, router *model.EdgeRouter) (*rest_m
 	isOnline := onlineEdgeRouter != nil
 
 	if isOnline {
-		hostname = *onlineEdgeRouter.Hostname
+		hostname = onlineEdgeRouter.Hostname
 		protocols = onlineEdgeRouter.EdgeRouterProtocols
 
 		if onlineEdgeRouter.VersionInfo != nil {
@@ -135,7 +135,6 @@ func MapEdgeRouterToRestModel(ae *env.AppEnv, router *model.EdgeRouter) (*rest_m
 			revision = onlineEdgeRouter.VersionInfo.Revision
 			version = onlineEdgeRouter.VersionInfo.Version
 		}
-
 	}
 
 	ret := &rest_model.EdgeRouterDetail{
@@ -149,7 +148,7 @@ func MapEdgeRouterToRestModel(ae *env.AppEnv, router *model.EdgeRouter) (*rest_m
 		IsOnline:            &isOnline,
 		IsVerified:          &router.IsVerified,
 		Fingerprint:         stringz.OrEmpty(router.Fingerprint),
-		Hostname:            &hostname,
+		Hostname:            hostname,
 		SupportedProtocols:  protocols,
 		SyncStatus:          &syncStatusStr,
 		VersionInfo: &rest_model.VersionInfo{

--- a/tests/ats-ctrl.yml
+++ b/tests/ats-ctrl.yml
@@ -1,7 +1,7 @@
 v: 3
 
-trace:
-  path: /tmp/ctrl.trace
+#trace:
+#  path: /tmp/ctrl.trace
 
 #profile:
 #  memory:


### PR DESCRIPTION
Hostnames may be a nil pointer at times now due to the fact that edge routers may be waiting to sync and might be "online" but edge hellos have not been exchanged.