### PR TITLE
fix swagger parameter names, allow mfa codes on headers for get/delete

### DIFF
--- a/controller/internal/routes/authenticate_router.go
+++ b/controller/internal/routes/authenticate_router.go
@@ -62,7 +62,7 @@ func (ro *AuthRouter) Register(ae *env.AppEnv) {
 func (ro *AuthRouter) authHandler(ae *env.AppEnv, rc *response.RequestContext, params authentication.AuthenticateParams) {
 	start := time.Now()
 	logger := pfxlog.Logger()
-	authContext := model.NewAuthContextHttp(params.HTTPRequest, params.Method, params.Body)
+	authContext := model.NewAuthContextHttp(params.HTTPRequest, params.Method, params.Auth)
 
 	identity, err := ae.Handlers.Authenticator.IsAuthorized(authContext)
 
@@ -115,8 +115,8 @@ func (ro *AuthRouter) authHandler(ae *env.AppEnv, rc *response.RequestContext, p
 	token := uuid.New().String()
 	configTypes := map[string]struct{}{}
 
-	if params.Body != nil {
-		configTypes = mapConfigTypeNamesToIds(ae, params.Body.ConfigTypes, identity.Id)
+	if params.Auth != nil {
+		configTypes = mapConfigTypeNamesToIds(ae, params.Auth.ConfigTypes, identity.Id)
 	}
 	remoteIpStr := ""
 	if remoteIp, _, err := net.SplitHostPort(rc.Request.RemoteAddr); err == nil {
@@ -188,7 +188,7 @@ func (ro *AuthRouter) authMfa(ae *env.AppEnv, rc *response.RequestContext, param
 		return
 	}
 
-	ok, _ := ae.Handlers.Mfa.Verify(mfa, *params.Body.Code)
+	ok, _ := ae.Handlers.Mfa.Verify(mfa, *params.MfaAuth.Code)
 
 	if !ok {
 		rc.RespondWithError(apierror.NewInvalidMfaTokenError())

--- a/controller/internal/routes/authenticator_router.go
+++ b/controller/internal/routes/authenticator_router.go
@@ -75,7 +75,7 @@ func (r *AuthenticatorRouter) Detail(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *AuthenticatorRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params authenticator.CreateAuthenticatorParams) {
 	Create(rc, rc, AuthenticatorLinkFactory, func() (string, error) {
-		return ae.Handlers.Authenticator.Create(MapCreateToAuthenticatorModel(params.Body))
+		return ae.Handlers.Authenticator.Create(MapCreateToAuthenticatorModel(params.Authenticator))
 	})
 }
 
@@ -85,13 +85,13 @@ func (r *AuthenticatorRouter) Delete(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *AuthenticatorRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params authenticator.UpdateAuthenticatorParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.Authenticator.Update(MapUpdateAuthenticatorToModel(params.ID, params.Body))
+		return ae.Handlers.Authenticator.Update(MapUpdateAuthenticatorToModel(params.ID, params.Authenticator))
 	})
 }
 
 func (r *AuthenticatorRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params authenticator.PatchAuthenticatorParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		model := MapPatchAuthenticatorToModel(params.ID, params.Body)
+		model := MapPatchAuthenticatorToModel(params.ID, params.Authenticator)
 
 		if fields.IsUpdated("password") {
 			fields.AddField("salt")

--- a/controller/internal/routes/ca_router.go
+++ b/controller/internal/routes/ca_router.go
@@ -98,7 +98,7 @@ func (r *CaRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *CaRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params certificate_authority.CreateCaParams) {
 	Create(rc, rc, CaLinkFactory, func() (string, error) {
-		return ae.Handlers.Ca.Create(MapCreateCaToModel(params.Body))
+		return ae.Handlers.Ca.Create(MapCreateCaToModel(params.Ca))
 	})
 }
 
@@ -108,13 +108,13 @@ func (r *CaRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *CaRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params certificate_authority.UpdateCaParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.Ca.Update(MapUpdateCaToModel(params.ID, params.Body))
+		return ae.Handlers.Ca.Update(MapUpdateCaToModel(params.ID, params.Ca))
 	})
 }
 
 func (r *CaRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params certificate_authority.PatchCaParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.Ca.Patch(MapPatchCaToModel(params.ID, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.Ca.Patch(MapPatchCaToModel(params.ID, params.Ca), fields.FilterMaps("tags"))
 	})
 }
 

--- a/controller/internal/routes/config_router.go
+++ b/controller/internal/routes/config_router.go
@@ -75,14 +75,14 @@ func (r *ConfigRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 func (r *ConfigRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params config.CreateConfigParams) {
-	if params.Body.Data == nil {
+	if params.Config.Data == nil {
 		ctx := middleware.MatchedRouteFrom(rc.Request)
 		ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.Required("data", "body", nil))
 		return
 	}
 
 	Create(rc, rc, ConfigLinkFactory, func() (string, error) {
-		return ae.Handlers.Config.Create(MapCreateConfigToModel(params.Body))
+		return ae.Handlers.Config.Create(MapCreateConfigToModel(params.Config))
 	})
 }
 
@@ -91,19 +91,19 @@ func (r *ConfigRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 func (r *ConfigRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params config.UpdateConfigParams) {
-	if params.Body.Data == nil {
+	if params.Config.Data == nil {
 		ctx := middleware.MatchedRouteFrom(rc.Request)
 		ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.Required("data", "body", nil))
 		return
 	}
 
 	Update(rc, func(id string) error {
-		return ae.Handlers.Config.Update(MapUpdateConfigToModel(params.ID, params.Body))
+		return ae.Handlers.Config.Update(MapUpdateConfigToModel(params.ID, params.Config))
 	})
 }
 
 func (r *ConfigRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params config.PatchConfigParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.Config.Patch(MapPatchConfigToModel(params.ID, params.Body), fields.FilterMaps("tags", "data"))
+		return ae.Handlers.Config.Patch(MapPatchConfigToModel(params.ID, params.Config), fields.FilterMaps("tags", "data"))
 	})
 }

--- a/controller/internal/routes/config_type_router.go
+++ b/controller/internal/routes/config_type_router.go
@@ -79,16 +79,16 @@ func (r *ConfigTypeRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 func (r *ConfigTypeRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params config.CreateConfigTypeParams) {
-	if params.Body.Schema != nil {
-		if _, ok := params.Body.Schema.(map[string]interface{}); !ok {
+	if params.ConfigType.Schema != nil {
+		if _, ok := params.ConfigType.Schema.(map[string]interface{}); !ok {
 			ctx := middleware.MatchedRouteFrom(rc.Request)
-			ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.Body.Schema))
+			ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.ConfigType.Schema))
 			return
 		}
 	}
 
 	Create(rc, rc, ConfigTypeLinkFactory, func() (string, error) {
-		return ae.Handlers.ConfigType.Create(MapCreateConfigTypeToModel(params.Body))
+		return ae.Handlers.ConfigType.Create(MapCreateConfigTypeToModel(params.ConfigType))
 	})
 }
 
@@ -97,34 +97,34 @@ func (r *ConfigTypeRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 func (r *ConfigTypeRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params config.UpdateConfigTypeParams) {
-	if params.Body.Schema != nil {
-		if _, ok := params.Body.Schema.(map[string]interface{}); !ok {
+	if params.ConfigType.Schema != nil {
+		if _, ok := params.ConfigType.Schema.(map[string]interface{}); !ok {
 			ctx := middleware.MatchedRouteFrom(rc.Request)
-			ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.Body.Schema))
+			ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.ConfigType.Schema))
 			return
 		}
 	}
 
 	Update(rc, func(id string) error {
-		return ae.Handlers.ConfigType.Update(MapUpdateConfigTypeToModel(params.ID, params.Body))
+		return ae.Handlers.ConfigType.Update(MapUpdateConfigTypeToModel(params.ID, params.ConfigType))
 	})
 }
 
 func (r *ConfigTypeRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params config.PatchConfigTypeParams) {
 
-	if _, ok := params.Body.Schema.(map[string]interface{}); !ok {
+	if _, ok := params.ConfigType.Schema.(map[string]interface{}); !ok {
 		ctx := middleware.MatchedRouteFrom(rc.Request)
-		ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.Body.Schema))
+		ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.InvalidType("schema", "body", "object", params.ConfigType.Schema))
 		return
 	}
-	if params.Body.Schema == nil {
+	if params.ConfigType.Schema == nil {
 		ctx := middleware.MatchedRouteFrom(rc.Request)
 		ae.Api.ServeErrorFor(ctx.Operation.ID)(rc.ResponseWriter, rc.Request, errors.Required("schema", "body", nil))
 		return
 	}
 
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.ConfigType.Patch(MapPatchConfigTypeToModel(params.ID, params.Body), fields.FilterMaps("tags", "schema"))
+		return ae.Handlers.ConfigType.Patch(MapPatchConfigTypeToModel(params.ID, params.ConfigType), fields.FilterMaps("tags", "schema"))
 	})
 }
 

--- a/controller/internal/routes/current_api_session_router.go
+++ b/controller/internal/routes/current_api_session_router.go
@@ -113,7 +113,7 @@ func (router *CurrentSessionRouter) ListCertificates(ae *env.AppEnv, rc *respons
 func (router *CurrentSessionRouter) CreateCertificate(ae *env.AppEnv, rc *response.RequestContext, params current_api_session.CreateCurrentAPISessionCertificateParams) {
 	responder := &ApiSessionCertificateCreateResponder{ae: ae, Responder: rc}
 	CreateWithResponder(rc, responder, CurrentApiSessionCertificateLinkFactory, func() (string, error) {
-		return ae.GetHandlers().ApiSessionCertificate.CreateFromCSR(rc.ApiSession.Id, 12*time.Hour, []byte(*params.Body.Csr))
+		return ae.GetHandlers().ApiSessionCertificate.CreateFromCSR(rc.ApiSession.Id, 12*time.Hour, []byte(*params.SessionCertificate.Csr))
 	})
 }
 

--- a/controller/internal/routes/current_identity_authenticator_router.go
+++ b/controller/internal/routes/current_identity_authenticator_router.go
@@ -109,12 +109,12 @@ func (r *CurrentIdentityAuthenticatorRouter) Detail(ae *env.AppEnv, rc *response
 
 func (r *CurrentIdentityAuthenticatorRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params current_api_session.UpdateCurrentIdentityAuthenticatorParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.Authenticator.UpdateSelf(MapUpdateAuthenticatorWithCurrentToModel(params.ID, rc.Identity.Id, params.Body))
+		return ae.Handlers.Authenticator.UpdateSelf(MapUpdateAuthenticatorWithCurrentToModel(params.ID, rc.Identity.Id, params.Authenticator))
 	})
 }
 
 func (r *CurrentIdentityAuthenticatorRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params current_api_session.PatchCurrentIdentityAuthenticatorParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.Authenticator.PatchSelf(MapPatchAuthenticatorWithCurrentToModel(params.ID, rc.Identity.Id, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.Authenticator.PatchSelf(MapPatchAuthenticatorWithCurrentToModel(params.ID, rc.Identity.Id, params.Authenticator), fields.FilterMaps("tags"))
 	})
 }

--- a/controller/internal/routes/edge_router_policy_router.go
+++ b/controller/internal/routes/edge_router_policy_router.go
@@ -85,7 +85,7 @@ func (r *EdgeRouterPolicyRouter) Detail(ae *env.AppEnv, rc *response.RequestCont
 
 func (r *EdgeRouterPolicyRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params edge_router_policy.CreateEdgeRouterPolicyParams) {
 	Create(rc, rc, EdgeRouterPolicyLinkFactory, func() (string, error) {
-		return ae.Handlers.EdgeRouterPolicy.Create(MapCreateEdgeRouterPolicyToModel(params.Body))
+		return ae.Handlers.EdgeRouterPolicy.Create(MapCreateEdgeRouterPolicyToModel(params.Policy))
 	})
 }
 
@@ -95,13 +95,13 @@ func (r *EdgeRouterPolicyRouter) Delete(ae *env.AppEnv, rc *response.RequestCont
 
 func (r *EdgeRouterPolicyRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params edge_router_policy.UpdateEdgeRouterPolicyParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.EdgeRouterPolicy.Update(MapUpdateEdgeRouterPolicyToModel(params.ID, params.Body))
+		return ae.Handlers.EdgeRouterPolicy.Update(MapUpdateEdgeRouterPolicyToModel(params.ID, params.Policy))
 	})
 }
 
 func (r *EdgeRouterPolicyRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params edge_router_policy.PatchEdgeRouterPolicyParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.EdgeRouterPolicy.Patch(MapPatchEdgeRouterPolicyToModel(params.ID, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.EdgeRouterPolicy.Patch(MapPatchEdgeRouterPolicyToModel(params.ID, params.Policy), fields.FilterMaps("tags"))
 	})
 }
 

--- a/controller/internal/routes/edge_router_router.go
+++ b/controller/internal/routes/edge_router_router.go
@@ -108,7 +108,7 @@ func (r *EdgeRouterRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *EdgeRouterRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params edge_router.CreateEdgeRouterParams) {
 	Create(rc, rc, EdgeRouterLinkFactory, func() (string, error) {
-		return ae.Handlers.EdgeRouter.Create(MapCreateEdgeRouterToModel(params.Body))
+		return ae.Handlers.EdgeRouter.Create(MapCreateEdgeRouterToModel(params.EdgeRouter))
 	})
 }
 
@@ -118,13 +118,13 @@ func (r *EdgeRouterRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *EdgeRouterRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params edge_router.UpdateEdgeRouterParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.EdgeRouter.Update(MapUpdateEdgeRouterToModel(params.ID, params.Body), true)
+		return ae.Handlers.EdgeRouter.Update(MapUpdateEdgeRouterToModel(params.ID, params.EdgeRouter), true)
 	})
 }
 
 func (r *EdgeRouterRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params edge_router.PatchEdgeRouterParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.EdgeRouter.Patch(MapPatchEdgeRouterToModel(params.ID, params.Body), fields)
+		return ae.Handlers.EdgeRouter.Patch(MapPatchEdgeRouterToModel(params.ID, params.EdgeRouter), fields)
 	})
 }
 

--- a/controller/internal/routes/identity_router.go
+++ b/controller/internal/routes/identity_router.go
@@ -159,7 +159,7 @@ func getIdentityTypeId(ae *env.AppEnv, identityType rest_model.IdentityType) str
 
 func (r *IdentityRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params identity.CreateIdentityParams) {
 	Create(rc, rc, IdentityLinkFactory, func() (string, error) {
-		identityModel, enrollments := MapCreateIdentityToModel(params.Body, getIdentityTypeId(ae, params.Body.Type))
+		identityModel, enrollments := MapCreateIdentityToModel(params.Identity, getIdentityTypeId(ae, params.Identity.Type))
 		identityId, _, err := ae.Handlers.Identity.CreateWithEnrollments(identityModel, enrollments)
 		return identityId, err
 	})
@@ -171,13 +171,13 @@ func (r *IdentityRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *IdentityRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params identity.UpdateIdentityParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.Identity.Update(MapUpdateIdentityToModel(params.ID, params.Body, getIdentityTypeId(ae, params.Body.Type)))
+		return ae.Handlers.Identity.Update(MapUpdateIdentityToModel(params.ID, params.Identity, getIdentityTypeId(ae, params.Identity.Type)))
 	})
 }
 
 func (r *IdentityRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params identity.PatchIdentityParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.Identity.Patch(MapPatchIdentityToModel(params.ID, params.Body, getIdentityTypeId(ae, params.Body.Type)), fields.FilterMaps("tags"))
+		return ae.Handlers.Identity.Patch(MapPatchIdentityToModel(params.ID, params.Identity, getIdentityTypeId(ae, params.Identity.Type)), fields.FilterMaps("tags"))
 	})
 }
 
@@ -233,7 +233,7 @@ func (r *IdentityRouter) listServiceConfigs(ae *env.AppEnv, rc *response.Request
 func (r *IdentityRouter) assignServiceConfigs(ae *env.AppEnv, rc *response.RequestContext, params identity.AssociateIdentitysServiceConfigsParams) {
 	Update(rc, func(id string) error {
 		var modelServiceConfigs []model.ServiceConfig
-		for _, serviceConfig := range params.Body {
+		for _, serviceConfig := range params.ServiceConfigs {
 			modelServiceConfigs = append(modelServiceConfigs, MapServiceConfigToModel(*serviceConfig))
 		}
 		return ae.Handlers.Identity.AssignServiceConfigs(id, modelServiceConfigs)
@@ -243,7 +243,7 @@ func (r *IdentityRouter) assignServiceConfigs(ae *env.AppEnv, rc *response.Reque
 func (r *IdentityRouter) removeServiceConfigs(ae *env.AppEnv, rc *response.RequestContext, params identity.DisassociateIdentitysServiceConfigsParams) {
 	UpdateAllowEmptyBody(rc, func(id string) error {
 		var modelServiceConfigs []model.ServiceConfig
-		for _, serviceConfig := range params.Body {
+		for _, serviceConfig := range params.ServiceConfigIDPairs {
 			modelServiceConfigs = append(modelServiceConfigs, MapServiceConfigToModel(*serviceConfig))
 		}
 		return ae.Handlers.Identity.RemoveServiceConfigs(id, modelServiceConfigs)

--- a/controller/internal/routes/posture_check_router.go
+++ b/controller/internal/routes/posture_check_router.go
@@ -117,7 +117,7 @@ func (r *PostureCheckRouter) Detail(ae *env.AppEnv, rc *response.RequestContext)
 
 func (r *PostureCheckRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params posture_checks.CreatePostureCheckParams) {
 	Create(rc, rc, PostureCheckLinkFactory, func() (string, error) {
-		return ae.Handlers.PostureCheck.Create(MapCreatePostureCheckToModel(params.Body))
+		return ae.Handlers.PostureCheck.Create(MapCreatePostureCheckToModel(params.PostureCheck))
 	})
 }
 
@@ -127,13 +127,13 @@ func (r *PostureCheckRouter) Delete(ae *env.AppEnv, rc *response.RequestContext)
 
 func (r *PostureCheckRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params posture_checks.UpdatePostureCheckParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.PostureCheck.Update(MapUpdatePostureCheckToModel(params.ID, params.Body))
+		return ae.Handlers.PostureCheck.Update(MapUpdatePostureCheckToModel(params.ID, params.PostureCheck))
 	})
 }
 
 func (r *PostureCheckRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params posture_checks.PatchPostureCheckParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		check := MapPatchPostureCheckToModel(params.ID, params.Body)
+		check := MapPatchPostureCheckToModel(params.ID, params.PostureCheck)
 
 		if fields.IsUpdated("operatingSystems") {
 			fields.AddField(persistence.FieldPostureCheckOsType)

--- a/controller/internal/routes/posture_response_router.go
+++ b/controller/internal/routes/posture_response_router.go
@@ -54,14 +54,14 @@ func (r *PostureResponseRouter) Register(ae *env.AppEnv) {
 
 func (r *PostureResponseRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params posture_checks.CreatePostureResponseParams) {
 	Create(rc, rc, PostureResponseLinkFactory, func() (string, error) {
-		apiPostureResponse := params.Body
+		apiPostureResponse := params.PostureResponse
 		r.handlePostureResponse(ae, rc, apiPostureResponse)
 		return "", nil
 	})
 }
 
 func (r *PostureResponseRouter) CreateBulk(ae *env.AppEnv, rc *response.RequestContext, params posture_checks.CreatePostureResponseBulkParams) {
-	for _, apiPostureResponse := range params.Body {
+	for _, apiPostureResponse := range params.PostureResponse {
 		r.handlePostureResponse(ae, rc, apiPostureResponse)
 	}
 

--- a/controller/internal/routes/service_edge_router_policy_router.go
+++ b/controller/internal/routes/service_edge_router_policy_router.go
@@ -85,7 +85,7 @@ func (r *ServiceEdgeRouterPolicyRouter) Detail(ae *env.AppEnv, rc *response.Requ
 
 func (r *ServiceEdgeRouterPolicyRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params service_edge_router_policy.CreateServiceEdgeRouterPolicyParams) {
 	Create(rc, rc, ServiceEdgeRouterPolicyLinkFactory, func() (string, error) {
-		return ae.Handlers.ServiceEdgeRouterPolicy.Create(MapCreateServiceEdgeRouterPolicyToModel(params.Body))
+		return ae.Handlers.ServiceEdgeRouterPolicy.Create(MapCreateServiceEdgeRouterPolicyToModel(params.Policy))
 	})
 }
 
@@ -95,13 +95,13 @@ func (r *ServiceEdgeRouterPolicyRouter) Delete(ae *env.AppEnv, rc *response.Requ
 
 func (r *ServiceEdgeRouterPolicyRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params service_edge_router_policy.UpdateServiceEdgeRouterPolicyParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.ServiceEdgeRouterPolicy.Update(MapUpdateServiceEdgeRouterPolicyToModel(params.ID, params.Body))
+		return ae.Handlers.ServiceEdgeRouterPolicy.Update(MapUpdateServiceEdgeRouterPolicyToModel(params.ID, params.Policy))
 	})
 }
 
 func (r *ServiceEdgeRouterPolicyRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params service_edge_router_policy.PatchServiceEdgeRouterPolicyParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.ServiceEdgeRouterPolicy.Patch(MapPatchServiceEdgeRouterPolicyToModel(params.ID, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.ServiceEdgeRouterPolicy.Patch(MapPatchServiceEdgeRouterPolicyToModel(params.ID, params.Policy), fields.FilterMaps("tags"))
 	})
 }
 

--- a/controller/internal/routes/service_policy_router.go
+++ b/controller/internal/routes/service_policy_router.go
@@ -89,7 +89,7 @@ func (r *ServicePolicyRouter) Detail(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *ServicePolicyRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params service_policy.CreateServicePolicyParams) {
 	Create(rc, rc, ServicePolicyLinkFactory, func() (string, error) {
-		return ae.Handlers.ServicePolicy.Create(MapCreateServicePolicyToModel(params.Body))
+		return ae.Handlers.ServicePolicy.Create(MapCreateServicePolicyToModel(params.Policy))
 	})
 }
 
@@ -99,13 +99,13 @@ func (r *ServicePolicyRouter) Delete(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *ServicePolicyRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params service_policy.UpdateServicePolicyParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.ServicePolicy.Update(MapUpdateServicePolicyToModel(params.ID, params.Body))
+		return ae.Handlers.ServicePolicy.Update(MapUpdateServicePolicyToModel(params.ID, params.Policy))
 	})
 }
 
 func (r *ServicePolicyRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params service_policy.PatchServicePolicyParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.ServicePolicy.Patch(MapPatchServicePolicyToModel(params.ID, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.ServicePolicy.Patch(MapPatchServicePolicyToModel(params.ID, params.Policy), fields.FilterMaps("tags"))
 	})
 }
 

--- a/controller/internal/routes/service_router.go
+++ b/controller/internal/routes/service_router.go
@@ -182,7 +182,7 @@ func (r *ServiceRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *ServiceRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params service.CreateServiceParams) {
 	Create(rc, rc, ServiceLinkFactory, func() (string, error) {
-		return ae.Handlers.EdgeService.Create(MapCreateServiceToModel(params.Body))
+		return ae.Handlers.EdgeService.Create(MapCreateServiceToModel(params.Service))
 	})
 }
 
@@ -192,13 +192,13 @@ func (r *ServiceRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *ServiceRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params service.UpdateServiceParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.EdgeService.Update(MapUpdateServiceToModel(params.ID, params.Body))
+		return ae.Handlers.EdgeService.Update(MapUpdateServiceToModel(params.ID, params.Service))
 	})
 }
 
 func (r *ServiceRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params service.PatchServiceParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.EdgeService.Patch(MapPatchServiceToModel(params.ID, params.Body), fields.ConcatNestedNames().FilterMaps("tags"))
+		return ae.Handlers.EdgeService.Patch(MapPatchServiceToModel(params.ID, params.Service), fields.ConcatNestedNames().FilterMaps("tags"))
 	})
 }
 

--- a/controller/internal/routes/session_router.go
+++ b/controller/internal/routes/session_router.go
@@ -103,7 +103,7 @@ func (r *SessionRouter) Create(ae *env.AppEnv, rc *response.RequestContext, para
 	start := time.Now()
 	responder := &SessionRequestResponder{ae: ae, Responder: rc}
 	CreateWithResponder(rc, responder, SessionLinkFactory, func() (string, error) {
-		return ae.Handlers.Session.Create(MapCreateSessionToModel(rc.ApiSession.Id, params.Body))
+		return ae.Handlers.Session.Create(MapCreateSessionToModel(rc.ApiSession.Id, params.Session))
 	})
 	r.createTimer.UpdateSince(start)
 }

--- a/controller/internal/routes/terminator_router.go
+++ b/controller/internal/routes/terminator_router.go
@@ -75,7 +75,7 @@ func (r *TerminatorRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *TerminatorRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params terminator.CreateTerminatorParams) {
 	Create(rc, rc, TerminatorLinkFactory, func() (string, error) {
-		return ae.Handlers.Terminator.Create(MapCreateTerminatorToModel(params.Body))
+		return ae.Handlers.Terminator.Create(MapCreateTerminatorToModel(params.Terminator))
 	})
 }
 
@@ -85,12 +85,12 @@ func (r *TerminatorRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
 
 func (r *TerminatorRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params terminator.UpdateTerminatorParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.Terminator.Update(MapUpdateTerminatorToModel(params.ID, params.Body))
+		return ae.Handlers.Terminator.Update(MapUpdateTerminatorToModel(params.ID, params.Terminator))
 	})
 }
 
 func (r *TerminatorRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params terminator.PatchTerminatorParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.Terminator.Patch(MapPatchTerminatorToModel(params.ID, params.Body), fields.FilterMaps("tags"))
+		return ae.Handlers.Terminator.Patch(MapPatchTerminatorToModel(params.ID, params.Terminator), fields.FilterMaps("tags"))
 	})
 }

--- a/controller/internal/routes/transit_router_router.go
+++ b/controller/internal/routes/transit_router_router.go
@@ -75,7 +75,7 @@ func (r *TransitRouterRouter) Detail(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *TransitRouterRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params transit_router.CreateTransitRouterParams) {
 	Create(rc, rc, TransitRouterLinkFactory, func() (string, error) {
-		return ae.Handlers.TransitRouter.Create(MapCreateTransitRouterToModel(params.Body))
+		return ae.Handlers.TransitRouter.Create(MapCreateTransitRouterToModel(params.Router))
 	})
 }
 
@@ -85,12 +85,12 @@ func (r *TransitRouterRouter) Delete(ae *env.AppEnv, rc *response.RequestContext
 
 func (r *TransitRouterRouter) Update(ae *env.AppEnv, rc *response.RequestContext, params transit_router.UpdateTransitRouterParams) {
 	Update(rc, func(id string) error {
-		return ae.Handlers.TransitRouter.Update(MapUpdateTransitRouterToModel(params.ID, params.Body), false)
+		return ae.Handlers.TransitRouter.Update(MapUpdateTransitRouterToModel(params.ID, params.Router), false)
 	})
 }
 
 func (r *TransitRouterRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, params transit_router.PatchTransitRouterParams) {
 	Patch(rc, func(id string, fields JsonFields) error {
-		return ae.Handlers.TransitRouter.Patch(MapPatchTransitRouterToModel(params.ID, params.Body), fields.ConcatNestedNames().FilterMaps("tags"), false)
+		return ae.Handlers.TransitRouter.Patch(MapPatchTransitRouterToModel(params.ID, params.Router), fields.ConcatNestedNames().FilterMaps("tags"), false)
 	})
 }

--- a/rest_client/authentication/authenticate_mfa_parameters.go
+++ b/rest_client/authentication/authenticate_mfa_parameters.go
@@ -86,11 +86,11 @@ for the authenticate mfa operation typically these are written to a http.Request
 */
 type AuthenticateMfaParams struct {
 
-	/*Body
+	/*MfaAuth
 	  An MFA validation request
 
 	*/
-	Body *rest_model.MfaCode
+	MfaAuth *rest_model.MfaCode
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *AuthenticateMfaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the authenticate mfa params
-func (o *AuthenticateMfaParams) WithBody(body *rest_model.MfaCode) *AuthenticateMfaParams {
-	o.SetBody(body)
+// WithMfaAuth adds the mfaAuth to the authenticate mfa params
+func (o *AuthenticateMfaParams) WithMfaAuth(mfaAuth *rest_model.MfaCode) *AuthenticateMfaParams {
+	o.SetMfaAuth(mfaAuth)
 	return o
 }
 
-// SetBody adds the body to the authenticate mfa params
-func (o *AuthenticateMfaParams) SetBody(body *rest_model.MfaCode) {
-	o.Body = body
+// SetMfaAuth adds the mfaAuth to the authenticate mfa params
+func (o *AuthenticateMfaParams) SetMfaAuth(mfaAuth *rest_model.MfaCode) {
+	o.MfaAuth = mfaAuth
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *AuthenticateMfaParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.MfaAuth != nil {
+		if err := r.SetBodyParam(o.MfaAuth); err != nil {
 			return err
 		}
 	}

--- a/rest_client/authentication/authenticate_parameters.go
+++ b/rest_client/authentication/authenticate_parameters.go
@@ -86,8 +86,8 @@ for the authenticate operation typically these are written to a http.Request
 */
 type AuthenticateParams struct {
 
-	/*Body*/
-	Body *rest_model.Authenticate
+	/*Auth*/
+	Auth *rest_model.Authenticate
 	/*Method*/
 	Method string
 
@@ -129,15 +129,15 @@ func (o *AuthenticateParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the authenticate params
-func (o *AuthenticateParams) WithBody(body *rest_model.Authenticate) *AuthenticateParams {
-	o.SetBody(body)
+// WithAuth adds the auth to the authenticate params
+func (o *AuthenticateParams) WithAuth(auth *rest_model.Authenticate) *AuthenticateParams {
+	o.SetAuth(auth)
 	return o
 }
 
-// SetBody adds the body to the authenticate params
-func (o *AuthenticateParams) SetBody(body *rest_model.Authenticate) {
-	o.Body = body
+// SetAuth adds the auth to the authenticate params
+func (o *AuthenticateParams) SetAuth(auth *rest_model.Authenticate) {
+	o.Auth = auth
 }
 
 // WithMethod adds the method to the authenticate params
@@ -159,8 +159,8 @@ func (o *AuthenticateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Auth != nil {
+		if err := r.SetBodyParam(o.Auth); err != nil {
 			return err
 		}
 	}

--- a/rest_client/authenticator/create_authenticator_parameters.go
+++ b/rest_client/authenticator/create_authenticator_parameters.go
@@ -86,11 +86,11 @@ for the create authenticator operation typically these are written to a http.Req
 */
 type CreateAuthenticatorParams struct {
 
-	/*Body
-	  A Authenticators create object
+	/*Authenticator
+	  A Authenticator create object
 
 	*/
-	Body *rest_model.AuthenticatorCreate
+	Authenticator *rest_model.AuthenticatorCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateAuthenticatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create authenticator params
-func (o *CreateAuthenticatorParams) WithBody(body *rest_model.AuthenticatorCreate) *CreateAuthenticatorParams {
-	o.SetBody(body)
+// WithAuthenticator adds the authenticator to the create authenticator params
+func (o *CreateAuthenticatorParams) WithAuthenticator(authenticator *rest_model.AuthenticatorCreate) *CreateAuthenticatorParams {
+	o.SetAuthenticator(authenticator)
 	return o
 }
 
-// SetBody adds the body to the create authenticator params
-func (o *CreateAuthenticatorParams) SetBody(body *rest_model.AuthenticatorCreate) {
-	o.Body = body
+// SetAuthenticator adds the authenticator to the create authenticator params
+func (o *CreateAuthenticatorParams) SetAuthenticator(authenticator *rest_model.AuthenticatorCreate) {
+	o.Authenticator = authenticator
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateAuthenticatorParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Authenticator != nil {
+		if err := r.SetBodyParam(o.Authenticator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/authenticator/patch_authenticator_parameters.go
+++ b/rest_client/authenticator/patch_authenticator_parameters.go
@@ -86,11 +86,11 @@ for the patch authenticator operation typically these are written to a http.Requ
 */
 type PatchAuthenticatorParams struct {
 
-	/*Body
+	/*Authenticator
 	  An authenticator patch object
 
 	*/
-	Body *rest_model.AuthenticatorPatch
+	Authenticator *rest_model.AuthenticatorPatch
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchAuthenticatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch authenticator params
-func (o *PatchAuthenticatorParams) WithBody(body *rest_model.AuthenticatorPatch) *PatchAuthenticatorParams {
-	o.SetBody(body)
+// WithAuthenticator adds the authenticator to the patch authenticator params
+func (o *PatchAuthenticatorParams) WithAuthenticator(authenticator *rest_model.AuthenticatorPatch) *PatchAuthenticatorParams {
+	o.SetAuthenticator(authenticator)
 	return o
 }
 
-// SetBody adds the body to the patch authenticator params
-func (o *PatchAuthenticatorParams) SetBody(body *rest_model.AuthenticatorPatch) {
-	o.Body = body
+// SetAuthenticator adds the authenticator to the patch authenticator params
+func (o *PatchAuthenticatorParams) SetAuthenticator(authenticator *rest_model.AuthenticatorPatch) {
+	o.Authenticator = authenticator
 }
 
 // WithID adds the id to the patch authenticator params
@@ -165,8 +165,8 @@ func (o *PatchAuthenticatorParams) WriteToRequest(r runtime.ClientRequest, reg s
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Authenticator != nil {
+		if err := r.SetBodyParam(o.Authenticator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/authenticator/update_authenticator_parameters.go
+++ b/rest_client/authenticator/update_authenticator_parameters.go
@@ -86,11 +86,11 @@ for the update authenticator operation typically these are written to a http.Req
 */
 type UpdateAuthenticatorParams struct {
 
-	/*Body
+	/*Authenticator
 	  An authenticator put object
 
 	*/
-	Body *rest_model.AuthenticatorUpdate
+	Authenticator *rest_model.AuthenticatorUpdate
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateAuthenticatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update authenticator params
-func (o *UpdateAuthenticatorParams) WithBody(body *rest_model.AuthenticatorUpdate) *UpdateAuthenticatorParams {
-	o.SetBody(body)
+// WithAuthenticator adds the authenticator to the update authenticator params
+func (o *UpdateAuthenticatorParams) WithAuthenticator(authenticator *rest_model.AuthenticatorUpdate) *UpdateAuthenticatorParams {
+	o.SetAuthenticator(authenticator)
 	return o
 }
 
-// SetBody adds the body to the update authenticator params
-func (o *UpdateAuthenticatorParams) SetBody(body *rest_model.AuthenticatorUpdate) {
-	o.Body = body
+// SetAuthenticator adds the authenticator to the update authenticator params
+func (o *UpdateAuthenticatorParams) SetAuthenticator(authenticator *rest_model.AuthenticatorUpdate) {
+	o.Authenticator = authenticator
 }
 
 // WithID adds the id to the update authenticator params
@@ -165,8 +165,8 @@ func (o *UpdateAuthenticatorParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Authenticator != nil {
+		if err := r.SetBodyParam(o.Authenticator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/certificate_authority/create_ca_parameters.go
+++ b/rest_client/certificate_authority/create_ca_parameters.go
@@ -86,11 +86,11 @@ for the create ca operation typically these are written to a http.Request
 */
 type CreateCaParams struct {
 
-	/*Body
+	/*Ca
 	  A CA to create
 
 	*/
-	Body *rest_model.CaCreate
+	Ca *rest_model.CaCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateCaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create ca params
-func (o *CreateCaParams) WithBody(body *rest_model.CaCreate) *CreateCaParams {
-	o.SetBody(body)
+// WithCa adds the ca to the create ca params
+func (o *CreateCaParams) WithCa(ca *rest_model.CaCreate) *CreateCaParams {
+	o.SetCa(ca)
 	return o
 }
 
-// SetBody adds the body to the create ca params
-func (o *CreateCaParams) SetBody(body *rest_model.CaCreate) {
-	o.Body = body
+// SetCa adds the ca to the create ca params
+func (o *CreateCaParams) SetCa(ca *rest_model.CaCreate) {
+	o.Ca = ca
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateCaParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Ca != nil {
+		if err := r.SetBodyParam(o.Ca); err != nil {
 			return err
 		}
 	}

--- a/rest_client/certificate_authority/patch_ca_parameters.go
+++ b/rest_client/certificate_authority/patch_ca_parameters.go
@@ -86,11 +86,11 @@ for the patch ca operation typically these are written to a http.Request
 */
 type PatchCaParams struct {
 
-	/*Body
+	/*Ca
 	  A CA patch object
 
 	*/
-	Body *rest_model.CaPatch
+	Ca *rest_model.CaPatch
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchCaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch ca params
-func (o *PatchCaParams) WithBody(body *rest_model.CaPatch) *PatchCaParams {
-	o.SetBody(body)
+// WithCa adds the ca to the patch ca params
+func (o *PatchCaParams) WithCa(ca *rest_model.CaPatch) *PatchCaParams {
+	o.SetCa(ca)
 	return o
 }
 
-// SetBody adds the body to the patch ca params
-func (o *PatchCaParams) SetBody(body *rest_model.CaPatch) {
-	o.Body = body
+// SetCa adds the ca to the patch ca params
+func (o *PatchCaParams) SetCa(ca *rest_model.CaPatch) {
+	o.Ca = ca
 }
 
 // WithID adds the id to the patch ca params
@@ -165,8 +165,8 @@ func (o *PatchCaParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regis
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Ca != nil {
+		if err := r.SetBodyParam(o.Ca); err != nil {
 			return err
 		}
 	}

--- a/rest_client/certificate_authority/update_ca_parameters.go
+++ b/rest_client/certificate_authority/update_ca_parameters.go
@@ -86,11 +86,11 @@ for the update ca operation typically these are written to a http.Request
 */
 type UpdateCaParams struct {
 
-	/*Body
+	/*Ca
 	  A CA update object
 
 	*/
-	Body *rest_model.CaUpdate
+	Ca *rest_model.CaUpdate
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateCaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update ca params
-func (o *UpdateCaParams) WithBody(body *rest_model.CaUpdate) *UpdateCaParams {
-	o.SetBody(body)
+// WithCa adds the ca to the update ca params
+func (o *UpdateCaParams) WithCa(ca *rest_model.CaUpdate) *UpdateCaParams {
+	o.SetCa(ca)
 	return o
 }
 
-// SetBody adds the body to the update ca params
-func (o *UpdateCaParams) SetBody(body *rest_model.CaUpdate) {
-	o.Body = body
+// SetCa adds the ca to the update ca params
+func (o *UpdateCaParams) SetCa(ca *rest_model.CaUpdate) {
+	o.Ca = ca
 }
 
 // WithID adds the id to the update ca params
@@ -165,8 +165,8 @@ func (o *UpdateCaParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Ca != nil {
+		if err := r.SetBodyParam(o.Ca); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/create_config_parameters.go
+++ b/rest_client/config/create_config_parameters.go
@@ -86,11 +86,11 @@ for the create config operation typically these are written to a http.Request
 */
 type CreateConfigParams struct {
 
-	/*Body
+	/*Config
 	  A config to create
 
 	*/
-	Body *rest_model.ConfigCreate
+	Config *rest_model.ConfigCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateConfigParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create config params
-func (o *CreateConfigParams) WithBody(body *rest_model.ConfigCreate) *CreateConfigParams {
-	o.SetBody(body)
+// WithConfig adds the config to the create config params
+func (o *CreateConfigParams) WithConfig(config *rest_model.ConfigCreate) *CreateConfigParams {
+	o.SetConfig(config)
 	return o
 }
 
-// SetBody adds the body to the create config params
-func (o *CreateConfigParams) SetBody(body *rest_model.ConfigCreate) {
-	o.Body = body
+// SetConfig adds the config to the create config params
+func (o *CreateConfigParams) SetConfig(config *rest_model.ConfigCreate) {
+	o.Config = config
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Config != nil {
+		if err := r.SetBodyParam(o.Config); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/create_config_type_parameters.go
+++ b/rest_client/config/create_config_type_parameters.go
@@ -86,11 +86,11 @@ for the create config type operation typically these are written to a http.Reque
 */
 type CreateConfigTypeParams struct {
 
-	/*Body
+	/*ConfigType
 	  A config-type to create
 
 	*/
-	Body *rest_model.ConfigTypeCreate
+	ConfigType *rest_model.ConfigTypeCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateConfigTypeParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create config type params
-func (o *CreateConfigTypeParams) WithBody(body *rest_model.ConfigTypeCreate) *CreateConfigTypeParams {
-	o.SetBody(body)
+// WithConfigType adds the configType to the create config type params
+func (o *CreateConfigTypeParams) WithConfigType(configType *rest_model.ConfigTypeCreate) *CreateConfigTypeParams {
+	o.SetConfigType(configType)
 	return o
 }
 
-// SetBody adds the body to the create config type params
-func (o *CreateConfigTypeParams) SetBody(body *rest_model.ConfigTypeCreate) {
-	o.Body = body
+// SetConfigType adds the configType to the create config type params
+func (o *CreateConfigTypeParams) SetConfigType(configType *rest_model.ConfigTypeCreate) {
+	o.ConfigType = configType
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateConfigTypeParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.ConfigType != nil {
+		if err := r.SetBodyParam(o.ConfigType); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/patch_config_parameters.go
+++ b/rest_client/config/patch_config_parameters.go
@@ -86,11 +86,11 @@ for the patch config operation typically these are written to a http.Request
 */
 type PatchConfigParams struct {
 
-	/*Body
+	/*Config
 	  A config patch object
 
 	*/
-	Body *rest_model.ConfigPatch
+	Config *rest_model.ConfigPatch
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchConfigParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch config params
-func (o *PatchConfigParams) WithBody(body *rest_model.ConfigPatch) *PatchConfigParams {
-	o.SetBody(body)
+// WithConfig adds the config to the patch config params
+func (o *PatchConfigParams) WithConfig(config *rest_model.ConfigPatch) *PatchConfigParams {
+	o.SetConfig(config)
 	return o
 }
 
-// SetBody adds the body to the patch config params
-func (o *PatchConfigParams) SetBody(body *rest_model.ConfigPatch) {
-	o.Body = body
+// SetConfig adds the config to the patch config params
+func (o *PatchConfigParams) SetConfig(config *rest_model.ConfigPatch) {
+	o.Config = config
 }
 
 // WithID adds the id to the patch config params
@@ -165,8 +165,8 @@ func (o *PatchConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Config != nil {
+		if err := r.SetBodyParam(o.Config); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/patch_config_type_parameters.go
+++ b/rest_client/config/patch_config_type_parameters.go
@@ -86,11 +86,11 @@ for the patch config type operation typically these are written to a http.Reques
 */
 type PatchConfigTypeParams struct {
 
-	/*Body
+	/*ConfigType
 	  A config-type patch object
 
 	*/
-	Body *rest_model.ConfigTypePatch
+	ConfigType *rest_model.ConfigTypePatch
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchConfigTypeParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch config type params
-func (o *PatchConfigTypeParams) WithBody(body *rest_model.ConfigTypePatch) *PatchConfigTypeParams {
-	o.SetBody(body)
+// WithConfigType adds the configType to the patch config type params
+func (o *PatchConfigTypeParams) WithConfigType(configType *rest_model.ConfigTypePatch) *PatchConfigTypeParams {
+	o.SetConfigType(configType)
 	return o
 }
 
-// SetBody adds the body to the patch config type params
-func (o *PatchConfigTypeParams) SetBody(body *rest_model.ConfigTypePatch) {
-	o.Body = body
+// SetConfigType adds the configType to the patch config type params
+func (o *PatchConfigTypeParams) SetConfigType(configType *rest_model.ConfigTypePatch) {
+	o.ConfigType = configType
 }
 
 // WithID adds the id to the patch config type params
@@ -165,8 +165,8 @@ func (o *PatchConfigTypeParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.ConfigType != nil {
+		if err := r.SetBodyParam(o.ConfigType); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/update_config_parameters.go
+++ b/rest_client/config/update_config_parameters.go
@@ -86,11 +86,11 @@ for the update config operation typically these are written to a http.Request
 */
 type UpdateConfigParams struct {
 
-	/*Body
+	/*Config
 	  A config update object
 
 	*/
-	Body *rest_model.ConfigUpdate
+	Config *rest_model.ConfigUpdate
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateConfigParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update config params
-func (o *UpdateConfigParams) WithBody(body *rest_model.ConfigUpdate) *UpdateConfigParams {
-	o.SetBody(body)
+// WithConfig adds the config to the update config params
+func (o *UpdateConfigParams) WithConfig(config *rest_model.ConfigUpdate) *UpdateConfigParams {
+	o.SetConfig(config)
 	return o
 }
 
-// SetBody adds the body to the update config params
-func (o *UpdateConfigParams) SetBody(body *rest_model.ConfigUpdate) {
-	o.Body = body
+// SetConfig adds the config to the update config params
+func (o *UpdateConfigParams) SetConfig(config *rest_model.ConfigUpdate) {
+	o.Config = config
 }
 
 // WithID adds the id to the update config params
@@ -165,8 +165,8 @@ func (o *UpdateConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Config != nil {
+		if err := r.SetBodyParam(o.Config); err != nil {
 			return err
 		}
 	}

--- a/rest_client/config/update_config_type_parameters.go
+++ b/rest_client/config/update_config_type_parameters.go
@@ -86,11 +86,11 @@ for the update config type operation typically these are written to a http.Reque
 */
 type UpdateConfigTypeParams struct {
 
-	/*Body
+	/*ConfigType
 	  A config-type update object
 
 	*/
-	Body *rest_model.ConfigTypeUpdate
+	ConfigType *rest_model.ConfigTypeUpdate
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateConfigTypeParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update config type params
-func (o *UpdateConfigTypeParams) WithBody(body *rest_model.ConfigTypeUpdate) *UpdateConfigTypeParams {
-	o.SetBody(body)
+// WithConfigType adds the configType to the update config type params
+func (o *UpdateConfigTypeParams) WithConfigType(configType *rest_model.ConfigTypeUpdate) *UpdateConfigTypeParams {
+	o.SetConfigType(configType)
 	return o
 }
 
-// SetBody adds the body to the update config type params
-func (o *UpdateConfigTypeParams) SetBody(body *rest_model.ConfigTypeUpdate) {
-	o.Body = body
+// SetConfigType adds the configType to the update config type params
+func (o *UpdateConfigTypeParams) SetConfigType(configType *rest_model.ConfigTypeUpdate) {
+	o.ConfigType = configType
 }
 
 // WithID adds the id to the update config type params
@@ -165,8 +165,8 @@ func (o *UpdateConfigTypeParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.ConfigType != nil {
+		if err := r.SetBodyParam(o.ConfigType); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_api_session/create_current_api_session_certificate_parameters.go
+++ b/rest_client/current_api_session/create_current_api_session_certificate_parameters.go
@@ -86,11 +86,11 @@ for the create current Api session certificate operation typically these are wri
 */
 type CreateCurrentAPISessionCertificateParams struct {
 
-	/*Body
+	/*SessionCertificate
 	  The payload describing the CSR used to create a session certificate
 
 	*/
-	Body *rest_model.CurrentAPISessionCertificateCreate
+	SessionCertificate *rest_model.CurrentAPISessionCertificateCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateCurrentAPISessionCertificateParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create current Api session certificate params
-func (o *CreateCurrentAPISessionCertificateParams) WithBody(body *rest_model.CurrentAPISessionCertificateCreate) *CreateCurrentAPISessionCertificateParams {
-	o.SetBody(body)
+// WithSessionCertificate adds the sessionCertificate to the create current Api session certificate params
+func (o *CreateCurrentAPISessionCertificateParams) WithSessionCertificate(sessionCertificate *rest_model.CurrentAPISessionCertificateCreate) *CreateCurrentAPISessionCertificateParams {
+	o.SetSessionCertificate(sessionCertificate)
 	return o
 }
 
-// SetBody adds the body to the create current Api session certificate params
-func (o *CreateCurrentAPISessionCertificateParams) SetBody(body *rest_model.CurrentAPISessionCertificateCreate) {
-	o.Body = body
+// SetSessionCertificate adds the sessionCertificate to the create current Api session certificate params
+func (o *CreateCurrentAPISessionCertificateParams) SetSessionCertificate(sessionCertificate *rest_model.CurrentAPISessionCertificateCreate) {
+	o.SessionCertificate = sessionCertificate
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateCurrentAPISessionCertificateParams) WriteToRequest(r runtime.Clie
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.SessionCertificate != nil {
+		if err := r.SetBodyParam(o.SessionCertificate); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_api_session/patch_current_identity_authenticator_parameters.go
+++ b/rest_client/current_api_session/patch_current_identity_authenticator_parameters.go
@@ -86,11 +86,11 @@ for the patch current identity authenticator operation typically these are writt
 */
 type PatchCurrentIdentityAuthenticatorParams struct {
 
-	/*Body
+	/*Authenticator
 	  An authenticator patch object
 
 	*/
-	Body *rest_model.AuthenticatorPatchWithCurrent
+	Authenticator *rest_model.AuthenticatorPatchWithCurrent
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchCurrentIdentityAuthenticatorParams) SetHTTPClient(client *http.Cli
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch current identity authenticator params
-func (o *PatchCurrentIdentityAuthenticatorParams) WithBody(body *rest_model.AuthenticatorPatchWithCurrent) *PatchCurrentIdentityAuthenticatorParams {
-	o.SetBody(body)
+// WithAuthenticator adds the authenticator to the patch current identity authenticator params
+func (o *PatchCurrentIdentityAuthenticatorParams) WithAuthenticator(authenticator *rest_model.AuthenticatorPatchWithCurrent) *PatchCurrentIdentityAuthenticatorParams {
+	o.SetAuthenticator(authenticator)
 	return o
 }
 
-// SetBody adds the body to the patch current identity authenticator params
-func (o *PatchCurrentIdentityAuthenticatorParams) SetBody(body *rest_model.AuthenticatorPatchWithCurrent) {
-	o.Body = body
+// SetAuthenticator adds the authenticator to the patch current identity authenticator params
+func (o *PatchCurrentIdentityAuthenticatorParams) SetAuthenticator(authenticator *rest_model.AuthenticatorPatchWithCurrent) {
+	o.Authenticator = authenticator
 }
 
 // WithID adds the id to the patch current identity authenticator params
@@ -165,8 +165,8 @@ func (o *PatchCurrentIdentityAuthenticatorParams) WriteToRequest(r runtime.Clien
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Authenticator != nil {
+		if err := r.SetBodyParam(o.Authenticator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_api_session/update_current_identity_authenticator_parameters.go
+++ b/rest_client/current_api_session/update_current_identity_authenticator_parameters.go
@@ -86,11 +86,11 @@ for the update current identity authenticator operation typically these are writ
 */
 type UpdateCurrentIdentityAuthenticatorParams struct {
 
-	/*Body
+	/*Authenticator
 	  An authenticator put object
 
 	*/
-	Body *rest_model.AuthenticatorUpdateWithCurrent
+	Authenticator *rest_model.AuthenticatorUpdateWithCurrent
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateCurrentIdentityAuthenticatorParams) SetHTTPClient(client *http.Cl
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update current identity authenticator params
-func (o *UpdateCurrentIdentityAuthenticatorParams) WithBody(body *rest_model.AuthenticatorUpdateWithCurrent) *UpdateCurrentIdentityAuthenticatorParams {
-	o.SetBody(body)
+// WithAuthenticator adds the authenticator to the update current identity authenticator params
+func (o *UpdateCurrentIdentityAuthenticatorParams) WithAuthenticator(authenticator *rest_model.AuthenticatorUpdateWithCurrent) *UpdateCurrentIdentityAuthenticatorParams {
+	o.SetAuthenticator(authenticator)
 	return o
 }
 
-// SetBody adds the body to the update current identity authenticator params
-func (o *UpdateCurrentIdentityAuthenticatorParams) SetBody(body *rest_model.AuthenticatorUpdateWithCurrent) {
-	o.Body = body
+// SetAuthenticator adds the authenticator to the update current identity authenticator params
+func (o *UpdateCurrentIdentityAuthenticatorParams) SetAuthenticator(authenticator *rest_model.AuthenticatorUpdateWithCurrent) {
+	o.Authenticator = authenticator
 }
 
 // WithID adds the id to the update current identity authenticator params
@@ -165,8 +165,8 @@ func (o *UpdateCurrentIdentityAuthenticatorParams) WriteToRequest(r runtime.Clie
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Authenticator != nil {
+		if err := r.SetBodyParam(o.Authenticator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_identity/create_mfa_recovery_codes_parameters.go
+++ b/rest_client/current_identity/create_mfa_recovery_codes_parameters.go
@@ -86,11 +86,11 @@ for the create mfa recovery codes operation typically these are written to a htt
 */
 type CreateMfaRecoveryCodesParams struct {
 
-	/*MfaCode
+	/*MfaValidation
 	  An MFA validation request
 
 	*/
-	MfaCode *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateMfaRecoveryCodesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithMfaCode adds the mfaCode to the create mfa recovery codes params
-func (o *CreateMfaRecoveryCodesParams) WithMfaCode(mfaCode *rest_model.MfaCode) *CreateMfaRecoveryCodesParams {
-	o.SetMfaCode(mfaCode)
+// WithMfaValidation adds the mfaValidation to the create mfa recovery codes params
+func (o *CreateMfaRecoveryCodesParams) WithMfaValidation(mfaValidation *rest_model.MfaCode) *CreateMfaRecoveryCodesParams {
+	o.SetMfaValidation(mfaValidation)
 	return o
 }
 
-// SetMfaCode adds the mfaCode to the create mfa recovery codes params
-func (o *CreateMfaRecoveryCodesParams) SetMfaCode(mfaCode *rest_model.MfaCode) {
-	o.MfaCode = mfaCode
+// SetMfaValidation adds the mfaValidation to the create mfa recovery codes params
+func (o *CreateMfaRecoveryCodesParams) SetMfaValidation(mfaValidation *rest_model.MfaCode) {
+	o.MfaValidation = mfaValidation
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateMfaRecoveryCodesParams) WriteToRequest(r runtime.ClientRequest, r
 	}
 	var res []error
 
-	if o.MfaCode != nil {
-		if err := r.SetBodyParam(o.MfaCode); err != nil {
+	if o.MfaValidation != nil {
+		if err := r.SetBodyParam(o.MfaValidation); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_identity/delete_mfa_parameters.go
+++ b/rest_client/current_identity/delete_mfa_parameters.go
@@ -86,11 +86,13 @@ for the delete mfa operation typically these are written to a http.Request
 */
 type DeleteMfaParams struct {
 
-	/*Body
+	/*MfaValidationCode*/
+	MfaValidationCode *string
+	/*MfaValidation
 	  An MFA validation request
 
 	*/
-	Body *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +132,26 @@ func (o *DeleteMfaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the delete mfa params
-func (o *DeleteMfaParams) WithBody(body *rest_model.MfaCode) *DeleteMfaParams {
-	o.SetBody(body)
+// WithMfaValidationCode adds the mfaValidationCode to the delete mfa params
+func (o *DeleteMfaParams) WithMfaValidationCode(mfaValidationCode *string) *DeleteMfaParams {
+	o.SetMfaValidationCode(mfaValidationCode)
 	return o
 }
 
-// SetBody adds the body to the delete mfa params
-func (o *DeleteMfaParams) SetBody(body *rest_model.MfaCode) {
-	o.Body = body
+// SetMfaValidationCode adds the mfaValidationCode to the delete mfa params
+func (o *DeleteMfaParams) SetMfaValidationCode(mfaValidationCode *string) {
+	o.MfaValidationCode = mfaValidationCode
+}
+
+// WithMfaValidation adds the mfaValidation to the delete mfa params
+func (o *DeleteMfaParams) WithMfaValidation(mfaValidation *rest_model.MfaCode) *DeleteMfaParams {
+	o.SetMfaValidation(mfaValidation)
+	return o
+}
+
+// SetMfaValidation adds the mfaValidation to the delete mfa params
+func (o *DeleteMfaParams) SetMfaValidation(mfaValidation *rest_model.MfaCode) {
+	o.MfaValidation = mfaValidation
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +162,17 @@ func (o *DeleteMfaParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.MfaValidationCode != nil {
+
+		// header param mfa-validation-code
+		if err := r.SetHeaderParam("mfa-validation-code", *o.MfaValidationCode); err != nil {
+			return err
+		}
+
+	}
+
+	if o.MfaValidation != nil {
+		if err := r.SetBodyParam(o.MfaValidation); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_identity/detail_mfa_recovery_codes_parameters.go
+++ b/rest_client/current_identity/detail_mfa_recovery_codes_parameters.go
@@ -86,11 +86,13 @@ for the detail mfa recovery codes operation typically these are written to a htt
 */
 type DetailMfaRecoveryCodesParams struct {
 
-	/*Body
+	/*MfaValidationCode*/
+	MfaValidationCode *string
+	/*MfaValidation
 	  An MFA validation request
 
 	*/
-	Body *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +132,26 @@ func (o *DetailMfaRecoveryCodesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the detail mfa recovery codes params
-func (o *DetailMfaRecoveryCodesParams) WithBody(body *rest_model.MfaCode) *DetailMfaRecoveryCodesParams {
-	o.SetBody(body)
+// WithMfaValidationCode adds the mfaValidationCode to the detail mfa recovery codes params
+func (o *DetailMfaRecoveryCodesParams) WithMfaValidationCode(mfaValidationCode *string) *DetailMfaRecoveryCodesParams {
+	o.SetMfaValidationCode(mfaValidationCode)
 	return o
 }
 
-// SetBody adds the body to the detail mfa recovery codes params
-func (o *DetailMfaRecoveryCodesParams) SetBody(body *rest_model.MfaCode) {
-	o.Body = body
+// SetMfaValidationCode adds the mfaValidationCode to the detail mfa recovery codes params
+func (o *DetailMfaRecoveryCodesParams) SetMfaValidationCode(mfaValidationCode *string) {
+	o.MfaValidationCode = mfaValidationCode
+}
+
+// WithMfaValidation adds the mfaValidation to the detail mfa recovery codes params
+func (o *DetailMfaRecoveryCodesParams) WithMfaValidation(mfaValidation *rest_model.MfaCode) *DetailMfaRecoveryCodesParams {
+	o.SetMfaValidation(mfaValidation)
+	return o
+}
+
+// SetMfaValidation adds the mfaValidation to the detail mfa recovery codes params
+func (o *DetailMfaRecoveryCodesParams) SetMfaValidation(mfaValidation *rest_model.MfaCode) {
+	o.MfaValidation = mfaValidation
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +162,17 @@ func (o *DetailMfaRecoveryCodesParams) WriteToRequest(r runtime.ClientRequest, r
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.MfaValidationCode != nil {
+
+		// header param mfa-validation-code
+		if err := r.SetHeaderParam("mfa-validation-code", *o.MfaValidationCode); err != nil {
+			return err
+		}
+
+	}
+
+	if o.MfaValidation != nil {
+		if err := r.SetBodyParam(o.MfaValidation); err != nil {
 			return err
 		}
 	}

--- a/rest_client/current_identity/verify_mfa_parameters.go
+++ b/rest_client/current_identity/verify_mfa_parameters.go
@@ -86,11 +86,11 @@ for the verify mfa operation typically these are written to a http.Request
 */
 type VerifyMfaParams struct {
 
-	/*Body
+	/*MfaValidation
 	  An MFA validation request
 
 	*/
-	Body *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *VerifyMfaParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the verify mfa params
-func (o *VerifyMfaParams) WithBody(body *rest_model.MfaCode) *VerifyMfaParams {
-	o.SetBody(body)
+// WithMfaValidation adds the mfaValidation to the verify mfa params
+func (o *VerifyMfaParams) WithMfaValidation(mfaValidation *rest_model.MfaCode) *VerifyMfaParams {
+	o.SetMfaValidation(mfaValidation)
 	return o
 }
 
-// SetBody adds the body to the verify mfa params
-func (o *VerifyMfaParams) SetBody(body *rest_model.MfaCode) {
-	o.Body = body
+// SetMfaValidation adds the mfaValidation to the verify mfa params
+func (o *VerifyMfaParams) SetMfaValidation(mfaValidation *rest_model.MfaCode) {
+	o.MfaValidation = mfaValidation
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *VerifyMfaParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.MfaValidation != nil {
+		if err := r.SetBodyParam(o.MfaValidation); err != nil {
 			return err
 		}
 	}

--- a/rest_client/edge_router/create_edge_router_parameters.go
+++ b/rest_client/edge_router/create_edge_router_parameters.go
@@ -86,11 +86,11 @@ for the create edge router operation typically these are written to a http.Reque
 */
 type CreateEdgeRouterParams struct {
 
-	/*Body
-	  A config-type to create
+	/*EdgeRouter
+	  A edge router to create
 
 	*/
-	Body *rest_model.EdgeRouterCreate
+	EdgeRouter *rest_model.EdgeRouterCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateEdgeRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create edge router params
-func (o *CreateEdgeRouterParams) WithBody(body *rest_model.EdgeRouterCreate) *CreateEdgeRouterParams {
-	o.SetBody(body)
+// WithEdgeRouter adds the edgeRouter to the create edge router params
+func (o *CreateEdgeRouterParams) WithEdgeRouter(edgeRouter *rest_model.EdgeRouterCreate) *CreateEdgeRouterParams {
+	o.SetEdgeRouter(edgeRouter)
 	return o
 }
 
-// SetBody adds the body to the create edge router params
-func (o *CreateEdgeRouterParams) SetBody(body *rest_model.EdgeRouterCreate) {
-	o.Body = body
+// SetEdgeRouter adds the edgeRouter to the create edge router params
+func (o *CreateEdgeRouterParams) SetEdgeRouter(edgeRouter *rest_model.EdgeRouterCreate) {
+	o.EdgeRouter = edgeRouter
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateEdgeRouterParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.EdgeRouter != nil {
+		if err := r.SetBodyParam(o.EdgeRouter); err != nil {
 			return err
 		}
 	}

--- a/rest_client/edge_router/patch_edge_router_parameters.go
+++ b/rest_client/edge_router/patch_edge_router_parameters.go
@@ -86,11 +86,11 @@ for the patch edge router operation typically these are written to a http.Reques
 */
 type PatchEdgeRouterParams struct {
 
-	/*Body
+	/*EdgeRouter
 	  An edge router patch object
 
 	*/
-	Body *rest_model.EdgeRouterPatch
+	EdgeRouter *rest_model.EdgeRouterPatch
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *PatchEdgeRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch edge router params
-func (o *PatchEdgeRouterParams) WithBody(body *rest_model.EdgeRouterPatch) *PatchEdgeRouterParams {
-	o.SetBody(body)
+// WithEdgeRouter adds the edgeRouter to the patch edge router params
+func (o *PatchEdgeRouterParams) WithEdgeRouter(edgeRouter *rest_model.EdgeRouterPatch) *PatchEdgeRouterParams {
+	o.SetEdgeRouter(edgeRouter)
 	return o
 }
 
-// SetBody adds the body to the patch edge router params
-func (o *PatchEdgeRouterParams) SetBody(body *rest_model.EdgeRouterPatch) {
-	o.Body = body
+// SetEdgeRouter adds the edgeRouter to the patch edge router params
+func (o *PatchEdgeRouterParams) SetEdgeRouter(edgeRouter *rest_model.EdgeRouterPatch) {
+	o.EdgeRouter = edgeRouter
 }
 
 // WithID adds the id to the patch edge router params
@@ -165,8 +165,8 @@ func (o *PatchEdgeRouterParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.EdgeRouter != nil {
+		if err := r.SetBodyParam(o.EdgeRouter); err != nil {
 			return err
 		}
 	}

--- a/rest_client/edge_router/update_edge_router_parameters.go
+++ b/rest_client/edge_router/update_edge_router_parameters.go
@@ -86,11 +86,11 @@ for the update edge router operation typically these are written to a http.Reque
 */
 type UpdateEdgeRouterParams struct {
 
-	/*Body
+	/*EdgeRouter
 	  An edge router update object
 
 	*/
-	Body *rest_model.EdgeRouterUpdate
+	EdgeRouter *rest_model.EdgeRouterUpdate
 	/*ID
 	  The id of the requested resource
 
@@ -135,15 +135,15 @@ func (o *UpdateEdgeRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update edge router params
-func (o *UpdateEdgeRouterParams) WithBody(body *rest_model.EdgeRouterUpdate) *UpdateEdgeRouterParams {
-	o.SetBody(body)
+// WithEdgeRouter adds the edgeRouter to the update edge router params
+func (o *UpdateEdgeRouterParams) WithEdgeRouter(edgeRouter *rest_model.EdgeRouterUpdate) *UpdateEdgeRouterParams {
+	o.SetEdgeRouter(edgeRouter)
 	return o
 }
 
-// SetBody adds the body to the update edge router params
-func (o *UpdateEdgeRouterParams) SetBody(body *rest_model.EdgeRouterUpdate) {
-	o.Body = body
+// SetEdgeRouter adds the edgeRouter to the update edge router params
+func (o *UpdateEdgeRouterParams) SetEdgeRouter(edgeRouter *rest_model.EdgeRouterUpdate) {
+	o.EdgeRouter = edgeRouter
 }
 
 // WithID adds the id to the update edge router params
@@ -165,8 +165,8 @@ func (o *UpdateEdgeRouterParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.EdgeRouter != nil {
+		if err := r.SetBodyParam(o.EdgeRouter); err != nil {
 			return err
 		}
 	}

--- a/rest_client/edge_router_policy/create_edge_router_policy_parameters.go
+++ b/rest_client/edge_router_policy/create_edge_router_policy_parameters.go
@@ -86,11 +86,11 @@ for the create edge router policy operation typically these are written to a htt
 */
 type CreateEdgeRouterPolicyParams struct {
 
-	/*Body
+	/*Policy
 	  An edge router policy to create
 
 	*/
-	Body *rest_model.EdgeRouterPolicyCreate
+	Policy *rest_model.EdgeRouterPolicyCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateEdgeRouterPolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create edge router policy params
-func (o *CreateEdgeRouterPolicyParams) WithBody(body *rest_model.EdgeRouterPolicyCreate) *CreateEdgeRouterPolicyParams {
-	o.SetBody(body)
+// WithPolicy adds the policy to the create edge router policy params
+func (o *CreateEdgeRouterPolicyParams) WithPolicy(policy *rest_model.EdgeRouterPolicyCreate) *CreateEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
 	return o
 }
 
-// SetBody adds the body to the create edge router policy params
-func (o *CreateEdgeRouterPolicyParams) SetBody(body *rest_model.EdgeRouterPolicyCreate) {
-	o.Body = body
+// SetPolicy adds the policy to the create edge router policy params
+func (o *CreateEdgeRouterPolicyParams) SetPolicy(policy *rest_model.EdgeRouterPolicyCreate) {
+	o.Policy = policy
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, r
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
 			return err
 		}
 	}

--- a/rest_client/edge_router_policy/patch_edge_router_policy_parameters.go
+++ b/rest_client/edge_router_policy/patch_edge_router_policy_parameters.go
@@ -86,16 +86,16 @@ for the patch edge router policy operation typically these are written to a http
 */
 type PatchEdgeRouterPolicyParams struct {
 
-	/*Body
-	  An edge router policy patch object
-
-	*/
-	Body *rest_model.EdgeRouterPolicyPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  An edge router policy patch object
+
+	*/
+	Policy *rest_model.EdgeRouterPolicyPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchEdgeRouterPolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch edge router policy params
-func (o *PatchEdgeRouterPolicyParams) WithBody(body *rest_model.EdgeRouterPolicyPatch) *PatchEdgeRouterPolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch edge router policy params
-func (o *PatchEdgeRouterPolicyParams) SetBody(body *rest_model.EdgeRouterPolicyPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch edge router policy params
 func (o *PatchEdgeRouterPolicyParams) WithID(id string) *PatchEdgeRouterPolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchEdgeRouterPolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the patch edge router policy params
+func (o *PatchEdgeRouterPolicyParams) WithPolicy(policy *rest_model.EdgeRouterPolicyPatch) *PatchEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the patch edge router policy params
+func (o *PatchEdgeRouterPolicyParams) SetPolicy(policy *rest_model.EdgeRouterPolicyPatch) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, re
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/edge_router_policy/update_edge_router_policy_parameters.go
+++ b/rest_client/edge_router_policy/update_edge_router_policy_parameters.go
@@ -86,16 +86,16 @@ for the update edge router policy operation typically these are written to a htt
 */
 type UpdateEdgeRouterPolicyParams struct {
 
-	/*Body
-	  An edge router policy update object
-
-	*/
-	Body *rest_model.EdgeRouterPolicyUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  An edge router policy update object
+
+	*/
+	Policy *rest_model.EdgeRouterPolicyUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateEdgeRouterPolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update edge router policy params
-func (o *UpdateEdgeRouterPolicyParams) WithBody(body *rest_model.EdgeRouterPolicyUpdate) *UpdateEdgeRouterPolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update edge router policy params
-func (o *UpdateEdgeRouterPolicyParams) SetBody(body *rest_model.EdgeRouterPolicyUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update edge router policy params
 func (o *UpdateEdgeRouterPolicyParams) WithID(id string) *UpdateEdgeRouterPolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateEdgeRouterPolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the update edge router policy params
+func (o *UpdateEdgeRouterPolicyParams) WithPolicy(policy *rest_model.EdgeRouterPolicyUpdate) *UpdateEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the update edge router policy params
+func (o *UpdateEdgeRouterPolicyParams) SetPolicy(policy *rest_model.EdgeRouterPolicyUpdate) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, r
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/identity/associate_identitys_service_configs_parameters.go
+++ b/rest_client/identity/associate_identitys_service_configs_parameters.go
@@ -86,16 +86,16 @@ for the associate identitys service configs operation typically these are writte
 */
 type AssociateIdentitysServiceConfigsParams struct {
 
-	/*Body
-	  An identity patch object
-
-	*/
-	Body rest_model.ServiceConfigsAssignList
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*ServiceConfigs
+	  A service config patch object
+
+	*/
+	ServiceConfigs rest_model.ServiceConfigsAssignList
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *AssociateIdentitysServiceConfigsParams) SetHTTPClient(client *http.Clie
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the associate identitys service configs params
-func (o *AssociateIdentitysServiceConfigsParams) WithBody(body rest_model.ServiceConfigsAssignList) *AssociateIdentitysServiceConfigsParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the associate identitys service configs params
-func (o *AssociateIdentitysServiceConfigsParams) SetBody(body rest_model.ServiceConfigsAssignList) {
-	o.Body = body
-}
-
 // WithID adds the id to the associate identitys service configs params
 func (o *AssociateIdentitysServiceConfigsParams) WithID(id string) *AssociateIdentitysServiceConfigsParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *AssociateIdentitysServiceConfigsParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithServiceConfigs adds the serviceConfigs to the associate identitys service configs params
+func (o *AssociateIdentitysServiceConfigsParams) WithServiceConfigs(serviceConfigs rest_model.ServiceConfigsAssignList) *AssociateIdentitysServiceConfigsParams {
+	o.SetServiceConfigs(serviceConfigs)
+	return o
+}
+
+// SetServiceConfigs adds the serviceConfigs to the associate identitys service configs params
+func (o *AssociateIdentitysServiceConfigsParams) SetServiceConfigs(serviceConfigs rest_model.ServiceConfigsAssignList) {
+	o.ServiceConfigs = serviceConfigs
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *AssociateIdentitysServiceConfigsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *AssociateIdentitysServiceConfigsParams) WriteToRequest(r runtime.Client
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.ServiceConfigs != nil {
+		if err := r.SetBodyParam(o.ServiceConfigs); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/identity/create_identity_parameters.go
+++ b/rest_client/identity/create_identity_parameters.go
@@ -86,11 +86,11 @@ for the create identity operation typically these are written to a http.Request
 */
 type CreateIdentityParams struct {
 
-	/*Body
+	/*Identity
 	  An identity to create
 
 	*/
-	Body *rest_model.IdentityCreate
+	Identity *rest_model.IdentityCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateIdentityParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create identity params
-func (o *CreateIdentityParams) WithBody(body *rest_model.IdentityCreate) *CreateIdentityParams {
-	o.SetBody(body)
+// WithIdentity adds the identity to the create identity params
+func (o *CreateIdentityParams) WithIdentity(identity *rest_model.IdentityCreate) *CreateIdentityParams {
+	o.SetIdentity(identity)
 	return o
 }
 
-// SetBody adds the body to the create identity params
-func (o *CreateIdentityParams) SetBody(body *rest_model.IdentityCreate) {
-	o.Body = body
+// SetIdentity adds the identity to the create identity params
+func (o *CreateIdentityParams) SetIdentity(identity *rest_model.IdentityCreate) {
+	o.Identity = identity
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateIdentityParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Identity != nil {
+		if err := r.SetBodyParam(o.Identity); err != nil {
 			return err
 		}
 	}

--- a/rest_client/identity/disassociate_identitys_service_configs_parameters.go
+++ b/rest_client/identity/disassociate_identitys_service_configs_parameters.go
@@ -86,16 +86,16 @@ for the disassociate identitys service configs operation typically these are wri
 */
 type DisassociateIdentitysServiceConfigsParams struct {
 
-	/*Body
-	  An array of service and config id pairs to remove
-
-	*/
-	Body rest_model.ServiceConfigsAssignList
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*ServiceConfigIDPairs
+	  An array of service and config id pairs to remove
+
+	*/
+	ServiceConfigIDPairs rest_model.ServiceConfigsAssignList
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *DisassociateIdentitysServiceConfigsParams) SetHTTPClient(client *http.C
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the disassociate identitys service configs params
-func (o *DisassociateIdentitysServiceConfigsParams) WithBody(body rest_model.ServiceConfigsAssignList) *DisassociateIdentitysServiceConfigsParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the disassociate identitys service configs params
-func (o *DisassociateIdentitysServiceConfigsParams) SetBody(body rest_model.ServiceConfigsAssignList) {
-	o.Body = body
-}
-
 // WithID adds the id to the disassociate identitys service configs params
 func (o *DisassociateIdentitysServiceConfigsParams) WithID(id string) *DisassociateIdentitysServiceConfigsParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *DisassociateIdentitysServiceConfigsParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithServiceConfigIDPairs adds the serviceConfigIDPairs to the disassociate identitys service configs params
+func (o *DisassociateIdentitysServiceConfigsParams) WithServiceConfigIDPairs(serviceConfigIDPairs rest_model.ServiceConfigsAssignList) *DisassociateIdentitysServiceConfigsParams {
+	o.SetServiceConfigIDPairs(serviceConfigIDPairs)
+	return o
+}
+
+// SetServiceConfigIDPairs adds the serviceConfigIdPairs to the disassociate identitys service configs params
+func (o *DisassociateIdentitysServiceConfigsParams) SetServiceConfigIDPairs(serviceConfigIDPairs rest_model.ServiceConfigsAssignList) {
+	o.ServiceConfigIDPairs = serviceConfigIDPairs
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *DisassociateIdentitysServiceConfigsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *DisassociateIdentitysServiceConfigsParams) WriteToRequest(r runtime.Cli
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.ServiceConfigIDPairs != nil {
+		if err := r.SetBodyParam(o.ServiceConfigIDPairs); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/identity/patch_identity_parameters.go
+++ b/rest_client/identity/patch_identity_parameters.go
@@ -86,16 +86,16 @@ for the patch identity operation typically these are written to a http.Request
 */
 type PatchIdentityParams struct {
 
-	/*Body
-	  An identity patch object
-
-	*/
-	Body *rest_model.IdentityPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Identity
+	  An identity patch object
+
+	*/
+	Identity *rest_model.IdentityPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchIdentityParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch identity params
-func (o *PatchIdentityParams) WithBody(body *rest_model.IdentityPatch) *PatchIdentityParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch identity params
-func (o *PatchIdentityParams) SetBody(body *rest_model.IdentityPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch identity params
 func (o *PatchIdentityParams) WithID(id string) *PatchIdentityParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchIdentityParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithIdentity adds the identity to the patch identity params
+func (o *PatchIdentityParams) WithIdentity(identity *rest_model.IdentityPatch) *PatchIdentityParams {
+	o.SetIdentity(identity)
+	return o
+}
+
+// SetIdentity adds the identity to the patch identity params
+func (o *PatchIdentityParams) SetIdentity(identity *rest_model.IdentityPatch) {
+	o.Identity = identity
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchIdentityParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchIdentityParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Identity != nil {
+		if err := r.SetBodyParam(o.Identity); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/identity/update_identity_parameters.go
+++ b/rest_client/identity/update_identity_parameters.go
@@ -86,16 +86,16 @@ for the update identity operation typically these are written to a http.Request
 */
 type UpdateIdentityParams struct {
 
-	/*Body
-	  An identity update object
-
-	*/
-	Body *rest_model.IdentityUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Identity
+	  An identity update object
+
+	*/
+	Identity *rest_model.IdentityUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateIdentityParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update identity params
-func (o *UpdateIdentityParams) WithBody(body *rest_model.IdentityUpdate) *UpdateIdentityParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update identity params
-func (o *UpdateIdentityParams) SetBody(body *rest_model.IdentityUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update identity params
 func (o *UpdateIdentityParams) WithID(id string) *UpdateIdentityParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateIdentityParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithIdentity adds the identity to the update identity params
+func (o *UpdateIdentityParams) WithIdentity(identity *rest_model.IdentityUpdate) *UpdateIdentityParams {
+	o.SetIdentity(identity)
+	return o
+}
+
+// SetIdentity adds the identity to the update identity params
+func (o *UpdateIdentityParams) SetIdentity(identity *rest_model.IdentityUpdate) {
+	o.Identity = identity
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateIdentityParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateIdentityParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Identity != nil {
+		if err := r.SetBodyParam(o.Identity); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/posture_checks/create_posture_check_parameters.go
+++ b/rest_client/posture_checks/create_posture_check_parameters.go
@@ -86,11 +86,11 @@ for the create posture check operation typically these are written to a http.Req
 */
 type CreatePostureCheckParams struct {
 
-	/*Body
-	  A Posture Checks to create
+	/*PostureCheck
+	  A Posture Check to create
 
 	*/
-	Body rest_model.PostureCheckCreate
+	PostureCheck rest_model.PostureCheckCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreatePostureCheckParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create posture check params
-func (o *CreatePostureCheckParams) WithBody(body rest_model.PostureCheckCreate) *CreatePostureCheckParams {
-	o.SetBody(body)
+// WithPostureCheck adds the postureCheck to the create posture check params
+func (o *CreatePostureCheckParams) WithPostureCheck(postureCheck rest_model.PostureCheckCreate) *CreatePostureCheckParams {
+	o.SetPostureCheck(postureCheck)
 	return o
 }
 
-// SetBody adds the body to the create posture check params
-func (o *CreatePostureCheckParams) SetBody(body rest_model.PostureCheckCreate) {
-	o.Body = body
+// SetPostureCheck adds the postureCheck to the create posture check params
+func (o *CreatePostureCheckParams) SetPostureCheck(postureCheck rest_model.PostureCheckCreate) {
+	o.PostureCheck = postureCheck
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,7 +149,7 @@ func (o *CreatePostureCheckParams) WriteToRequest(r runtime.ClientRequest, reg s
 	}
 	var res []error
 
-	if err := r.SetBodyParam(o.Body); err != nil {
+	if err := r.SetBodyParam(o.PostureCheck); err != nil {
 		return err
 	}
 

--- a/rest_client/posture_checks/create_posture_response_bulk_parameters.go
+++ b/rest_client/posture_checks/create_posture_response_bulk_parameters.go
@@ -86,11 +86,11 @@ for the create posture response bulk operation typically these are written to a 
 */
 type CreatePostureResponseBulkParams struct {
 
-	/*Body
+	/*PostureResponse
 	  A Posture Response
 
 	*/
-	Body []rest_model.PostureResponseCreate
+	PostureResponse []rest_model.PostureResponseCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreatePostureResponseBulkParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create posture response bulk params
-func (o *CreatePostureResponseBulkParams) WithBody(body []rest_model.PostureResponseCreate) *CreatePostureResponseBulkParams {
-	o.SetBody(body)
+// WithPostureResponse adds the postureResponse to the create posture response bulk params
+func (o *CreatePostureResponseBulkParams) WithPostureResponse(postureResponse []rest_model.PostureResponseCreate) *CreatePostureResponseBulkParams {
+	o.SetPostureResponse(postureResponse)
 	return o
 }
 
-// SetBody adds the body to the create posture response bulk params
-func (o *CreatePostureResponseBulkParams) SetBody(body []rest_model.PostureResponseCreate) {
-	o.Body = body
+// SetPostureResponse adds the postureResponse to the create posture response bulk params
+func (o *CreatePostureResponseBulkParams) SetPostureResponse(postureResponse []rest_model.PostureResponseCreate) {
+	o.PostureResponse = postureResponse
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreatePostureResponseBulkParams) WriteToRequest(r runtime.ClientRequest
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.PostureResponse != nil {
+		if err := r.SetBodyParam(o.PostureResponse); err != nil {
 			return err
 		}
 	}

--- a/rest_client/posture_checks/create_posture_response_parameters.go
+++ b/rest_client/posture_checks/create_posture_response_parameters.go
@@ -86,11 +86,11 @@ for the create posture response operation typically these are written to a http.
 */
 type CreatePostureResponseParams struct {
 
-	/*Body
+	/*PostureResponse
 	  A Posture Response
 
 	*/
-	Body rest_model.PostureResponseCreate
+	PostureResponse rest_model.PostureResponseCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreatePostureResponseParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create posture response params
-func (o *CreatePostureResponseParams) WithBody(body rest_model.PostureResponseCreate) *CreatePostureResponseParams {
-	o.SetBody(body)
+// WithPostureResponse adds the postureResponse to the create posture response params
+func (o *CreatePostureResponseParams) WithPostureResponse(postureResponse rest_model.PostureResponseCreate) *CreatePostureResponseParams {
+	o.SetPostureResponse(postureResponse)
 	return o
 }
 
-// SetBody adds the body to the create posture response params
-func (o *CreatePostureResponseParams) SetBody(body rest_model.PostureResponseCreate) {
-	o.Body = body
+// SetPostureResponse adds the postureResponse to the create posture response params
+func (o *CreatePostureResponseParams) SetPostureResponse(postureResponse rest_model.PostureResponseCreate) {
+	o.PostureResponse = postureResponse
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,7 +149,7 @@ func (o *CreatePostureResponseParams) WriteToRequest(r runtime.ClientRequest, re
 	}
 	var res []error
 
-	if err := r.SetBodyParam(o.Body); err != nil {
+	if err := r.SetBodyParam(o.PostureResponse); err != nil {
 		return err
 	}
 

--- a/rest_client/posture_checks/patch_posture_check_parameters.go
+++ b/rest_client/posture_checks/patch_posture_check_parameters.go
@@ -86,16 +86,16 @@ for the patch posture check operation typically these are written to a http.Requ
 */
 type PatchPostureCheckParams struct {
 
-	/*Body
-	  A Posture Checks patch object
-
-	*/
-	Body rest_model.PostureCheckPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*PostureCheck
+	  A Posture Check patch object
+
+	*/
+	PostureCheck rest_model.PostureCheckPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchPostureCheckParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch posture check params
-func (o *PatchPostureCheckParams) WithBody(body rest_model.PostureCheckPatch) *PatchPostureCheckParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch posture check params
-func (o *PatchPostureCheckParams) SetBody(body rest_model.PostureCheckPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch posture check params
 func (o *PatchPostureCheckParams) WithID(id string) *PatchPostureCheckParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchPostureCheckParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPostureCheck adds the postureCheck to the patch posture check params
+func (o *PatchPostureCheckParams) WithPostureCheck(postureCheck rest_model.PostureCheckPatch) *PatchPostureCheckParams {
+	o.SetPostureCheck(postureCheck)
+	return o
+}
+
+// SetPostureCheck adds the postureCheck to the patch posture check params
+func (o *PatchPostureCheckParams) SetPostureCheck(postureCheck rest_model.PostureCheckPatch) {
+	o.PostureCheck = postureCheck
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchPostureCheckParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,12 +165,12 @@ func (o *PatchPostureCheckParams) WriteToRequest(r runtime.ClientRequest, reg st
 	}
 	var res []error
 
-	if err := r.SetBodyParam(o.Body); err != nil {
+	// path param id
+	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
 	}
 
-	// path param id
-	if err := r.SetPathParam("id", o.ID); err != nil {
+	if err := r.SetBodyParam(o.PostureCheck); err != nil {
 		return err
 	}
 

--- a/rest_client/posture_checks/update_posture_check_parameters.go
+++ b/rest_client/posture_checks/update_posture_check_parameters.go
@@ -86,16 +86,16 @@ for the update posture check operation typically these are written to a http.Req
 */
 type UpdatePostureCheckParams struct {
 
-	/*Body
-	  A Posture Checks update object
-
-	*/
-	Body rest_model.PostureCheckUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*PostureCheck
+	  A Posture Check update object
+
+	*/
+	PostureCheck rest_model.PostureCheckUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdatePostureCheckParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update posture check params
-func (o *UpdatePostureCheckParams) WithBody(body rest_model.PostureCheckUpdate) *UpdatePostureCheckParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update posture check params
-func (o *UpdatePostureCheckParams) SetBody(body rest_model.PostureCheckUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update posture check params
 func (o *UpdatePostureCheckParams) WithID(id string) *UpdatePostureCheckParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdatePostureCheckParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPostureCheck adds the postureCheck to the update posture check params
+func (o *UpdatePostureCheckParams) WithPostureCheck(postureCheck rest_model.PostureCheckUpdate) *UpdatePostureCheckParams {
+	o.SetPostureCheck(postureCheck)
+	return o
+}
+
+// SetPostureCheck adds the postureCheck to the update posture check params
+func (o *UpdatePostureCheckParams) SetPostureCheck(postureCheck rest_model.PostureCheckUpdate) {
+	o.PostureCheck = postureCheck
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdatePostureCheckParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,12 +165,12 @@ func (o *UpdatePostureCheckParams) WriteToRequest(r runtime.ClientRequest, reg s
 	}
 	var res []error
 
-	if err := r.SetBodyParam(o.Body); err != nil {
+	// path param id
+	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
 	}
 
-	// path param id
-	if err := r.SetPathParam("id", o.ID); err != nil {
+	if err := r.SetBodyParam(o.PostureCheck); err != nil {
 		return err
 	}
 

--- a/rest_client/service/create_service_parameters.go
+++ b/rest_client/service/create_service_parameters.go
@@ -86,11 +86,11 @@ for the create service operation typically these are written to a http.Request
 */
 type CreateServiceParams struct {
 
-	/*Body
+	/*Service
 	  A service to create
 
 	*/
-	Body *rest_model.ServiceCreate
+	Service *rest_model.ServiceCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateServiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create service params
-func (o *CreateServiceParams) WithBody(body *rest_model.ServiceCreate) *CreateServiceParams {
-	o.SetBody(body)
+// WithService adds the service to the create service params
+func (o *CreateServiceParams) WithService(service *rest_model.ServiceCreate) *CreateServiceParams {
+	o.SetService(service)
 	return o
 }
 
-// SetBody adds the body to the create service params
-func (o *CreateServiceParams) SetBody(body *rest_model.ServiceCreate) {
-	o.Body = body
+// SetService adds the service to the create service params
+func (o *CreateServiceParams) SetService(service *rest_model.ServiceCreate) {
+	o.Service = service
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Service != nil {
+		if err := r.SetBodyParam(o.Service); err != nil {
 			return err
 		}
 	}

--- a/rest_client/service/patch_service_parameters.go
+++ b/rest_client/service/patch_service_parameters.go
@@ -86,16 +86,16 @@ for the patch service operation typically these are written to a http.Request
 */
 type PatchServiceParams struct {
 
-	/*Body
-	  A service patch object
-
-	*/
-	Body *rest_model.ServicePatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Service
+	  A service patch object
+
+	*/
+	Service *rest_model.ServicePatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchServiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch service params
-func (o *PatchServiceParams) WithBody(body *rest_model.ServicePatch) *PatchServiceParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch service params
-func (o *PatchServiceParams) SetBody(body *rest_model.ServicePatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch service params
 func (o *PatchServiceParams) WithID(id string) *PatchServiceParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchServiceParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithService adds the service to the patch service params
+func (o *PatchServiceParams) WithService(service *rest_model.ServicePatch) *PatchServiceParams {
+	o.SetService(service)
+	return o
+}
+
+// SetService adds the service to the patch service params
+func (o *PatchServiceParams) SetService(service *rest_model.ServicePatch) {
+	o.Service = service
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Service != nil {
+		if err := r.SetBodyParam(o.Service); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/service/update_service_parameters.go
+++ b/rest_client/service/update_service_parameters.go
@@ -86,16 +86,16 @@ for the update service operation typically these are written to a http.Request
 */
 type UpdateServiceParams struct {
 
-	/*Body
-	  A service update object
-
-	*/
-	Body *rest_model.ServiceUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Service
+	  A service update object
+
+	*/
+	Service *rest_model.ServiceUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateServiceParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update service params
-func (o *UpdateServiceParams) WithBody(body *rest_model.ServiceUpdate) *UpdateServiceParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update service params
-func (o *UpdateServiceParams) SetBody(body *rest_model.ServiceUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update service params
 func (o *UpdateServiceParams) WithID(id string) *UpdateServiceParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateServiceParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithService adds the service to the update service params
+func (o *UpdateServiceParams) WithService(service *rest_model.ServiceUpdate) *UpdateServiceParams {
+	o.SetService(service)
+	return o
+}
+
+// SetService adds the service to the update service params
+func (o *UpdateServiceParams) SetService(service *rest_model.ServiceUpdate) {
+	o.Service = service
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateServiceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Service != nil {
+		if err := r.SetBodyParam(o.Service); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/service_edge_router_policy/create_service_edge_router_policy_parameters.go
+++ b/rest_client/service_edge_router_policy/create_service_edge_router_policy_parameters.go
@@ -86,11 +86,11 @@ for the create service edge router policy operation typically these are written 
 */
 type CreateServiceEdgeRouterPolicyParams struct {
 
-	/*Body
+	/*Policy
 	  A service edge router policy to create
 
 	*/
-	Body *rest_model.ServiceEdgeRouterPolicyCreate
+	Policy *rest_model.ServiceEdgeRouterPolicyCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateServiceEdgeRouterPolicyParams) SetHTTPClient(client *http.Client)
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create service edge router policy params
-func (o *CreateServiceEdgeRouterPolicyParams) WithBody(body *rest_model.ServiceEdgeRouterPolicyCreate) *CreateServiceEdgeRouterPolicyParams {
-	o.SetBody(body)
+// WithPolicy adds the policy to the create service edge router policy params
+func (o *CreateServiceEdgeRouterPolicyParams) WithPolicy(policy *rest_model.ServiceEdgeRouterPolicyCreate) *CreateServiceEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
 	return o
 }
 
-// SetBody adds the body to the create service edge router policy params
-func (o *CreateServiceEdgeRouterPolicyParams) SetBody(body *rest_model.ServiceEdgeRouterPolicyCreate) {
-	o.Body = body
+// SetPolicy adds the policy to the create service edge router policy params
+func (o *CreateServiceEdgeRouterPolicyParams) SetPolicy(policy *rest_model.ServiceEdgeRouterPolicyCreate) {
+	o.Policy = policy
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateServiceEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientReq
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
 			return err
 		}
 	}

--- a/rest_client/service_edge_router_policy/patch_service_edge_router_policy_parameters.go
+++ b/rest_client/service_edge_router_policy/patch_service_edge_router_policy_parameters.go
@@ -86,16 +86,16 @@ for the patch service edge router policy operation typically these are written t
 */
 type PatchServiceEdgeRouterPolicyParams struct {
 
-	/*Body
-	  A service edge router policy patch object
-
-	*/
-	Body *rest_model.ServiceEdgeRouterPolicyPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  A service edge router policy patch object
+
+	*/
+	Policy *rest_model.ServiceEdgeRouterPolicyPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchServiceEdgeRouterPolicyParams) SetHTTPClient(client *http.Client) 
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch service edge router policy params
-func (o *PatchServiceEdgeRouterPolicyParams) WithBody(body *rest_model.ServiceEdgeRouterPolicyPatch) *PatchServiceEdgeRouterPolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch service edge router policy params
-func (o *PatchServiceEdgeRouterPolicyParams) SetBody(body *rest_model.ServiceEdgeRouterPolicyPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch service edge router policy params
 func (o *PatchServiceEdgeRouterPolicyParams) WithID(id string) *PatchServiceEdgeRouterPolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchServiceEdgeRouterPolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the patch service edge router policy params
+func (o *PatchServiceEdgeRouterPolicyParams) WithPolicy(policy *rest_model.ServiceEdgeRouterPolicyPatch) *PatchServiceEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the patch service edge router policy params
+func (o *PatchServiceEdgeRouterPolicyParams) SetPolicy(policy *rest_model.ServiceEdgeRouterPolicyPatch) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchServiceEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchServiceEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequ
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/service_edge_router_policy/update_service_edge_router_policy_parameters.go
+++ b/rest_client/service_edge_router_policy/update_service_edge_router_policy_parameters.go
@@ -86,16 +86,16 @@ for the update service edge router policy operation typically these are written 
 */
 type UpdateServiceEdgeRouterPolicyParams struct {
 
-	/*Body
-	  A service edge router policy update object
-
-	*/
-	Body *rest_model.ServiceEdgeRouterPolicyUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  A service edge router policy update object
+
+	*/
+	Policy *rest_model.ServiceEdgeRouterPolicyUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateServiceEdgeRouterPolicyParams) SetHTTPClient(client *http.Client)
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update service edge router policy params
-func (o *UpdateServiceEdgeRouterPolicyParams) WithBody(body *rest_model.ServiceEdgeRouterPolicyUpdate) *UpdateServiceEdgeRouterPolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update service edge router policy params
-func (o *UpdateServiceEdgeRouterPolicyParams) SetBody(body *rest_model.ServiceEdgeRouterPolicyUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update service edge router policy params
 func (o *UpdateServiceEdgeRouterPolicyParams) WithID(id string) *UpdateServiceEdgeRouterPolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateServiceEdgeRouterPolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the update service edge router policy params
+func (o *UpdateServiceEdgeRouterPolicyParams) WithPolicy(policy *rest_model.ServiceEdgeRouterPolicyUpdate) *UpdateServiceEdgeRouterPolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the update service edge router policy params
+func (o *UpdateServiceEdgeRouterPolicyParams) SetPolicy(policy *rest_model.ServiceEdgeRouterPolicyUpdate) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateServiceEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateServiceEdgeRouterPolicyParams) WriteToRequest(r runtime.ClientReq
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/service_policy/create_service_policy_parameters.go
+++ b/rest_client/service_policy/create_service_policy_parameters.go
@@ -86,11 +86,11 @@ for the create service policy operation typically these are written to a http.Re
 */
 type CreateServicePolicyParams struct {
 
-	/*Body
+	/*Policy
 	  A service policy to create
 
 	*/
-	Body *rest_model.ServicePolicyCreate
+	Policy *rest_model.ServicePolicyCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateServicePolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create service policy params
-func (o *CreateServicePolicyParams) WithBody(body *rest_model.ServicePolicyCreate) *CreateServicePolicyParams {
-	o.SetBody(body)
+// WithPolicy adds the policy to the create service policy params
+func (o *CreateServicePolicyParams) WithPolicy(policy *rest_model.ServicePolicyCreate) *CreateServicePolicyParams {
+	o.SetPolicy(policy)
 	return o
 }
 
-// SetBody adds the body to the create service policy params
-func (o *CreateServicePolicyParams) SetBody(body *rest_model.ServicePolicyCreate) {
-	o.Body = body
+// SetPolicy adds the policy to the create service policy params
+func (o *CreateServicePolicyParams) SetPolicy(policy *rest_model.ServicePolicyCreate) {
+	o.Policy = policy
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateServicePolicyParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
 			return err
 		}
 	}

--- a/rest_client/service_policy/patch_service_policy_parameters.go
+++ b/rest_client/service_policy/patch_service_policy_parameters.go
@@ -86,16 +86,16 @@ for the patch service policy operation typically these are written to a http.Req
 */
 type PatchServicePolicyParams struct {
 
-	/*Body
-	  A service policy patch object
-
-	*/
-	Body *rest_model.ServicePolicyPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  A service policy patch object
+
+	*/
+	Policy *rest_model.ServicePolicyPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchServicePolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch service policy params
-func (o *PatchServicePolicyParams) WithBody(body *rest_model.ServicePolicyPatch) *PatchServicePolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch service policy params
-func (o *PatchServicePolicyParams) SetBody(body *rest_model.ServicePolicyPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch service policy params
 func (o *PatchServicePolicyParams) WithID(id string) *PatchServicePolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchServicePolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the patch service policy params
+func (o *PatchServicePolicyParams) WithPolicy(policy *rest_model.ServicePolicyPatch) *PatchServicePolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the patch service policy params
+func (o *PatchServicePolicyParams) SetPolicy(policy *rest_model.ServicePolicyPatch) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchServicePolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchServicePolicyParams) WriteToRequest(r runtime.ClientRequest, reg s
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/service_policy/update_service_policy_parameters.go
+++ b/rest_client/service_policy/update_service_policy_parameters.go
@@ -86,16 +86,16 @@ for the update service policy operation typically these are written to a http.Re
 */
 type UpdateServicePolicyParams struct {
 
-	/*Body
-	  A service policy update object
-
-	*/
-	Body *rest_model.ServicePolicyUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Policy
+	  A service policy update object
+
+	*/
+	Policy *rest_model.ServicePolicyUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateServicePolicyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update service policy params
-func (o *UpdateServicePolicyParams) WithBody(body *rest_model.ServicePolicyUpdate) *UpdateServicePolicyParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update service policy params
-func (o *UpdateServicePolicyParams) SetBody(body *rest_model.ServicePolicyUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update service policy params
 func (o *UpdateServicePolicyParams) WithID(id string) *UpdateServicePolicyParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateServicePolicyParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithPolicy adds the policy to the update service policy params
+func (o *UpdateServicePolicyParams) WithPolicy(policy *rest_model.ServicePolicyUpdate) *UpdateServicePolicyParams {
+	o.SetPolicy(policy)
+	return o
+}
+
+// SetPolicy adds the policy to the update service policy params
+func (o *UpdateServicePolicyParams) SetPolicy(policy *rest_model.ServicePolicyUpdate) {
+	o.Policy = policy
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateServicePolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateServicePolicyParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Policy != nil {
+		if err := r.SetBodyParam(o.Policy); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/session/create_session_parameters.go
+++ b/rest_client/session/create_session_parameters.go
@@ -86,11 +86,11 @@ for the create session operation typically these are written to a http.Request
 */
 type CreateSessionParams struct {
 
-	/*Body
+	/*Session
 	  A session to create
 
 	*/
-	Body *rest_model.SessionCreate
+	Session *rest_model.SessionCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateSessionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create session params
-func (o *CreateSessionParams) WithBody(body *rest_model.SessionCreate) *CreateSessionParams {
-	o.SetBody(body)
+// WithSession adds the session to the create session params
+func (o *CreateSessionParams) WithSession(session *rest_model.SessionCreate) *CreateSessionParams {
+	o.SetSession(session)
 	return o
 }
 
-// SetBody adds the body to the create session params
-func (o *CreateSessionParams) SetBody(body *rest_model.SessionCreate) {
-	o.Body = body
+// SetSession adds the session to the create session params
+func (o *CreateSessionParams) SetSession(session *rest_model.SessionCreate) {
+	o.Session = session
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateSessionParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Session != nil {
+		if err := r.SetBodyParam(o.Session); err != nil {
 			return err
 		}
 	}

--- a/rest_client/terminator/create_terminator_parameters.go
+++ b/rest_client/terminator/create_terminator_parameters.go
@@ -86,11 +86,11 @@ for the create terminator operation typically these are written to a http.Reques
 */
 type CreateTerminatorParams struct {
 
-	/*Body
+	/*Terminator
 	  A terminator to create
 
 	*/
-	Body *rest_model.TerminatorCreate
+	Terminator *rest_model.TerminatorCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateTerminatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create terminator params
-func (o *CreateTerminatorParams) WithBody(body *rest_model.TerminatorCreate) *CreateTerminatorParams {
-	o.SetBody(body)
+// WithTerminator adds the terminator to the create terminator params
+func (o *CreateTerminatorParams) WithTerminator(terminator *rest_model.TerminatorCreate) *CreateTerminatorParams {
+	o.SetTerminator(terminator)
 	return o
 }
 
-// SetBody adds the body to the create terminator params
-func (o *CreateTerminatorParams) SetBody(body *rest_model.TerminatorCreate) {
-	o.Body = body
+// SetTerminator adds the terminator to the create terminator params
+func (o *CreateTerminatorParams) SetTerminator(terminator *rest_model.TerminatorCreate) {
+	o.Terminator = terminator
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateTerminatorParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Terminator != nil {
+		if err := r.SetBodyParam(o.Terminator); err != nil {
 			return err
 		}
 	}

--- a/rest_client/terminator/patch_terminator_parameters.go
+++ b/rest_client/terminator/patch_terminator_parameters.go
@@ -86,16 +86,16 @@ for the patch terminator operation typically these are written to a http.Request
 */
 type PatchTerminatorParams struct {
 
-	/*Body
-	  A terminator patch object
-
-	*/
-	Body *rest_model.TerminatorPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Terminator
+	  A terminator patch object
+
+	*/
+	Terminator *rest_model.TerminatorPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchTerminatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch terminator params
-func (o *PatchTerminatorParams) WithBody(body *rest_model.TerminatorPatch) *PatchTerminatorParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch terminator params
-func (o *PatchTerminatorParams) SetBody(body *rest_model.TerminatorPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch terminator params
 func (o *PatchTerminatorParams) WithID(id string) *PatchTerminatorParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchTerminatorParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithTerminator adds the terminator to the patch terminator params
+func (o *PatchTerminatorParams) WithTerminator(terminator *rest_model.TerminatorPatch) *PatchTerminatorParams {
+	o.SetTerminator(terminator)
+	return o
+}
+
+// SetTerminator adds the terminator to the patch terminator params
+func (o *PatchTerminatorParams) SetTerminator(terminator *rest_model.TerminatorPatch) {
+	o.Terminator = terminator
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchTerminatorParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchTerminatorParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Terminator != nil {
+		if err := r.SetBodyParam(o.Terminator); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/terminator/update_terminator_parameters.go
+++ b/rest_client/terminator/update_terminator_parameters.go
@@ -86,16 +86,16 @@ for the update terminator operation typically these are written to a http.Reques
 */
 type UpdateTerminatorParams struct {
 
-	/*Body
-	  A terminator update object
-
-	*/
-	Body *rest_model.TerminatorUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Terminator
+	  A terminator update object
+
+	*/
+	Terminator *rest_model.TerminatorUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateTerminatorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update terminator params
-func (o *UpdateTerminatorParams) WithBody(body *rest_model.TerminatorUpdate) *UpdateTerminatorParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update terminator params
-func (o *UpdateTerminatorParams) SetBody(body *rest_model.TerminatorUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update terminator params
 func (o *UpdateTerminatorParams) WithID(id string) *UpdateTerminatorParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateTerminatorParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithTerminator adds the terminator to the update terminator params
+func (o *UpdateTerminatorParams) WithTerminator(terminator *rest_model.TerminatorUpdate) *UpdateTerminatorParams {
+	o.SetTerminator(terminator)
+	return o
+}
+
+// SetTerminator adds the terminator to the update terminator params
+func (o *UpdateTerminatorParams) SetTerminator(terminator *rest_model.TerminatorUpdate) {
+	o.Terminator = terminator
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateTerminatorParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateTerminatorParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Terminator != nil {
+		if err := r.SetBodyParam(o.Terminator); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/transit_router/create_transit_router_parameters.go
+++ b/rest_client/transit_router/create_transit_router_parameters.go
@@ -86,11 +86,11 @@ for the create transit router operation typically these are written to a http.Re
 */
 type CreateTransitRouterParams struct {
 
-	/*Body
+	/*Router
 	  A transit router to create
 
 	*/
-	Body *rest_model.TransitRouterCreate
+	Router *rest_model.TransitRouterCreate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -130,15 +130,15 @@ func (o *CreateTransitRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the create transit router params
-func (o *CreateTransitRouterParams) WithBody(body *rest_model.TransitRouterCreate) *CreateTransitRouterParams {
-	o.SetBody(body)
+// WithRouter adds the router to the create transit router params
+func (o *CreateTransitRouterParams) WithRouter(router *rest_model.TransitRouterCreate) *CreateTransitRouterParams {
+	o.SetRouter(router)
 	return o
 }
 
-// SetBody adds the body to the create transit router params
-func (o *CreateTransitRouterParams) SetBody(body *rest_model.TransitRouterCreate) {
-	o.Body = body
+// SetRouter adds the router to the create transit router params
+func (o *CreateTransitRouterParams) SetRouter(router *rest_model.TransitRouterCreate) {
+	o.Router = router
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -149,8 +149,8 @@ func (o *CreateTransitRouterParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
+	if o.Router != nil {
+		if err := r.SetBodyParam(o.Router); err != nil {
 			return err
 		}
 	}

--- a/rest_client/transit_router/patch_transit_router_parameters.go
+++ b/rest_client/transit_router/patch_transit_router_parameters.go
@@ -86,16 +86,16 @@ for the patch transit router operation typically these are written to a http.Req
 */
 type PatchTransitRouterParams struct {
 
-	/*Body
-	  A transit router patch object
-
-	*/
-	Body *rest_model.TransitRouterPatch
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Router
+	  A transit router patch object
+
+	*/
+	Router *rest_model.TransitRouterPatch
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *PatchTransitRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the patch transit router params
-func (o *PatchTransitRouterParams) WithBody(body *rest_model.TransitRouterPatch) *PatchTransitRouterParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the patch transit router params
-func (o *PatchTransitRouterParams) SetBody(body *rest_model.TransitRouterPatch) {
-	o.Body = body
-}
-
 // WithID adds the id to the patch transit router params
 func (o *PatchTransitRouterParams) WithID(id string) *PatchTransitRouterParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *PatchTransitRouterParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithRouter adds the router to the patch transit router params
+func (o *PatchTransitRouterParams) WithRouter(router *rest_model.TransitRouterPatch) *PatchTransitRouterParams {
+	o.SetRouter(router)
+	return o
+}
+
+// SetRouter adds the router to the patch transit router params
+func (o *PatchTransitRouterParams) SetRouter(router *rest_model.TransitRouterPatch) {
+	o.Router = router
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchTransitRouterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *PatchTransitRouterParams) WriteToRequest(r runtime.ClientRequest, reg s
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Router != nil {
+		if err := r.SetBodyParam(o.Router); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_client/transit_router/update_transit_router_parameters.go
+++ b/rest_client/transit_router/update_transit_router_parameters.go
@@ -86,16 +86,16 @@ for the update transit router operation typically these are written to a http.Re
 */
 type UpdateTransitRouterParams struct {
 
-	/*Body
-	  A transit router update object
-
-	*/
-	Body *rest_model.TransitRouterUpdate
 	/*ID
 	  The id of the requested resource
 
 	*/
 	ID string
+	/*Router
+	  A transit router update object
+
+	*/
+	Router *rest_model.TransitRouterUpdate
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,17 +135,6 @@ func (o *UpdateTransitRouterParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the update transit router params
-func (o *UpdateTransitRouterParams) WithBody(body *rest_model.TransitRouterUpdate) *UpdateTransitRouterParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the update transit router params
-func (o *UpdateTransitRouterParams) SetBody(body *rest_model.TransitRouterUpdate) {
-	o.Body = body
-}
-
 // WithID adds the id to the update transit router params
 func (o *UpdateTransitRouterParams) WithID(id string) *UpdateTransitRouterParams {
 	o.SetID(id)
@@ -157,6 +146,17 @@ func (o *UpdateTransitRouterParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithRouter adds the router to the update transit router params
+func (o *UpdateTransitRouterParams) WithRouter(router *rest_model.TransitRouterUpdate) *UpdateTransitRouterParams {
+	o.SetRouter(router)
+	return o
+}
+
+// SetRouter adds the router to the update transit router params
+func (o *UpdateTransitRouterParams) SetRouter(router *rest_model.TransitRouterUpdate) {
+	o.Router = router
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateTransitRouterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,15 +165,15 @@ func (o *UpdateTransitRouterParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
-
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
+	}
+
+	if o.Router != nil {
+		if err := r.SetBodyParam(o.Router); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -198,7 +198,7 @@ func init() {
         "operationId": "authenticate",
         "parameters": [
           {
-            "name": "Body",
+            "name": "auth",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/authenticate"
@@ -240,7 +240,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaAuth",
             "in": "body",
             "required": true,
             "schema": {
@@ -291,8 +291,8 @@ func init() {
         "operationId": "createAuthenticator",
         "parameters": [
           {
-            "description": "A Authenticators create object",
-            "name": "Body",
+            "description": "A Authenticator create object",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -356,7 +356,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator put object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -418,7 +418,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator patch object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -492,7 +492,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA to create",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -553,7 +553,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA update object",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -615,7 +615,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA patch object",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -776,7 +776,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type to create",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -837,7 +837,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type update object",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -902,7 +902,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type patch object",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -1004,7 +1004,7 @@ func init() {
         "parameters": [
           {
             "description": "A config to create",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -1065,7 +1065,7 @@ func init() {
         "parameters": [
           {
             "description": "A config update object",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -1130,7 +1130,7 @@ func init() {
         "parameters": [
           {
             "description": "A config patch object",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -1247,7 +1247,7 @@ func init() {
         "parameters": [
           {
             "description": "The payload describing the CSR used to create a session certificate",
-            "name": "Body",
+            "name": "sessionCertificate",
             "in": "body",
             "required": true,
             "schema": {
@@ -1444,7 +1444,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator put object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -1482,7 +1482,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator patch object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -1602,12 +1602,16 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/mfaCode"
             }
+          },
+          {
+            "type": "string",
+            "name": "mfa-validation-code",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1668,12 +1672,16 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/mfaCode"
             }
+          },
+          {
+            "type": "string",
+            "name": "mfa-validation-code",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1704,7 +1712,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "mfaCode",
+            "name": "mfaValidation",
             "in": "body",
             "required": true,
             "schema": {
@@ -1742,7 +1750,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
             "required": true,
             "schema": {
@@ -1912,7 +1920,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -1973,7 +1981,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -2038,7 +2046,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -2216,8 +2224,8 @@ func init() {
         "operationId": "createEdgeRouter",
         "parameters": [
           {
-            "description": "A config-type to create",
-            "name": "Body",
+            "description": "A edge router to create",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -2278,7 +2286,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router update object",
-            "name": "Body",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -2343,7 +2351,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router patch object",
-            "name": "Body",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -2847,7 +2855,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity to create",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -2908,7 +2916,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity update object",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -2973,7 +2981,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity patch object",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -3200,8 +3208,8 @@ func init() {
         "operationId": "associateIdentitysServiceConfigs",
         "parameters": [
           {
-            "description": "An identity patch object",
-            "name": "Body",
+            "description": "A service config patch object",
+            "name": "serviceConfigs",
             "in": "body",
             "required": true,
             "schema": {
@@ -3239,7 +3247,7 @@ func init() {
         "parameters": [
           {
             "description": "An array of service and config id pairs to remove",
-            "name": "Body",
+            "name": "serviceConfigIdPairs",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/serviceConfigsAssignList"
@@ -3546,8 +3554,8 @@ func init() {
         "operationId": "createPostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks to create",
-            "name": "Body",
+            "description": "A Posture Check to create",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -3607,8 +3615,8 @@ func init() {
         "operationId": "updatePostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks update object",
-            "name": "Body",
+            "description": "A Posture Check update object",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -3669,8 +3677,8 @@ func init() {
         "operationId": "patchPostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks patch object",
-            "name": "Body",
+            "description": "A Posture Check patch object",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -3715,7 +3723,7 @@ func init() {
         "parameters": [
           {
             "description": "A Posture Response",
-            "name": "Body",
+            "name": "postureResponse",
             "in": "body",
             "required": true,
             "schema": {
@@ -3752,7 +3760,7 @@ func init() {
         "parameters": [
           {
             "description": "A Posture Response",
-            "name": "Body",
+            "name": "postureResponse",
             "in": "body",
             "required": true,
             "schema": {
@@ -3839,7 +3847,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -3900,7 +3908,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -3965,7 +3973,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -4104,7 +4112,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -4165,7 +4173,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -4230,7 +4238,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -4473,7 +4481,7 @@ func init() {
         "parameters": [
           {
             "description": "A service to create",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -4534,7 +4542,7 @@ func init() {
         "parameters": [
           {
             "description": "A service update object",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -4599,7 +4607,7 @@ func init() {
         "parameters": [
           {
             "description": "A service patch object",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -4910,7 +4918,7 @@ func init() {
         "parameters": [
           {
             "description": "A session to create",
-            "name": "Body",
+            "name": "session",
             "in": "body",
             "required": true,
             "schema": {
@@ -5122,7 +5130,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator to create",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -5183,7 +5191,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator update object",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -5248,7 +5256,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator patch object",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -5325,7 +5333,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router to create",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {
@@ -5386,7 +5394,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router update object",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {
@@ -5451,7 +5459,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router patch object",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {
@@ -11202,7 +11210,7 @@ func init() {
         "operationId": "authenticate",
         "parameters": [
           {
-            "name": "Body",
+            "name": "auth",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/authenticate"
@@ -11345,7 +11353,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaAuth",
             "in": "body",
             "required": true,
             "schema": {
@@ -11405,8 +11413,8 @@ func init() {
         "operationId": "createAuthenticator",
         "parameters": [
           {
-            "description": "A Authenticators create object",
-            "name": "Body",
+            "description": "A Authenticator create object",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -11572,7 +11580,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator put object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -11773,7 +11781,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator patch object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -11941,7 +11949,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA to create",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -12107,7 +12115,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA update object",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -12308,7 +12316,7 @@ func init() {
         "parameters": [
           {
             "description": "A CA patch object",
-            "name": "Body",
+            "name": "ca",
             "in": "body",
             "required": true,
             "schema": {
@@ -12696,7 +12704,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type to create",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -12862,7 +12870,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type update object",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -13088,7 +13096,7 @@ func init() {
         "parameters": [
           {
             "description": "A config-type patch object",
-            "name": "Body",
+            "name": "configType",
             "in": "body",
             "required": true,
             "schema": {
@@ -13312,7 +13320,7 @@ func init() {
         "parameters": [
           {
             "description": "A config to create",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -13478,7 +13486,7 @@ func init() {
         "parameters": [
           {
             "description": "A config update object",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -13704,7 +13712,7 @@ func init() {
         "parameters": [
           {
             "description": "A config patch object",
-            "name": "Body",
+            "name": "config",
             "in": "body",
             "required": true,
             "schema": {
@@ -13999,7 +14007,7 @@ func init() {
         "parameters": [
           {
             "description": "The payload describing the CSR used to create a session certificate",
-            "name": "Body",
+            "name": "sessionCertificate",
             "in": "body",
             "required": true,
             "schema": {
@@ -14532,7 +14540,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator put object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -14651,7 +14659,7 @@ func init() {
         "parameters": [
           {
             "description": "An authenticator patch object",
-            "name": "Body",
+            "name": "authenticator",
             "in": "body",
             "required": true,
             "schema": {
@@ -14970,12 +14978,16 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/mfaCode"
             }
+          },
+          {
+            "type": "string",
+            "name": "mfa-validation-code",
+            "in": "header"
           }
         ],
         "responses": {
@@ -15083,12 +15095,16 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/mfaCode"
             }
+          },
+          {
+            "type": "string",
+            "name": "mfa-validation-code",
+            "in": "header"
           }
         ],
         "responses": {
@@ -15166,7 +15182,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "mfaCode",
+            "name": "mfaValidation",
             "in": "body",
             "required": true,
             "schema": {
@@ -15251,7 +15267,7 @@ func init() {
         "parameters": [
           {
             "description": "An MFA validation request",
-            "name": "Body",
+            "name": "mfaValidation",
             "in": "body",
             "required": true,
             "schema": {
@@ -15654,7 +15670,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -15820,7 +15836,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -16046,7 +16062,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -16479,8 +16495,8 @@ func init() {
         "operationId": "createEdgeRouter",
         "parameters": [
           {
-            "description": "A config-type to create",
-            "name": "Body",
+            "description": "A edge router to create",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -16646,7 +16662,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router update object",
-            "name": "Body",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -16872,7 +16888,7 @@ func init() {
         "parameters": [
           {
             "description": "An edge router patch object",
-            "name": "Body",
+            "name": "edgeRouter",
             "in": "body",
             "required": true,
             "schema": {
@@ -18055,7 +18071,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity to create",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -18221,7 +18237,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity update object",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -18447,7 +18463,7 @@ func init() {
         "parameters": [
           {
             "description": "An identity patch object",
-            "name": "Body",
+            "name": "identity",
             "in": "body",
             "required": true,
             "schema": {
@@ -19065,8 +19081,8 @@ func init() {
         "operationId": "associateIdentitysServiceConfigs",
         "parameters": [
           {
-            "description": "An identity patch object",
-            "name": "Body",
+            "description": "A service config patch object",
+            "name": "serviceConfigs",
             "in": "body",
             "required": true,
             "schema": {
@@ -19185,7 +19201,7 @@ func init() {
         "parameters": [
           {
             "description": "An array of service and config id pairs to remove",
-            "name": "Body",
+            "name": "serviceConfigIdPairs",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/serviceConfigsAssignList"
@@ -19867,8 +19883,8 @@ func init() {
         "operationId": "createPostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks to create",
-            "name": "Body",
+            "description": "A Posture Check to create",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -20033,8 +20049,8 @@ func init() {
         "operationId": "updatePostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks update object",
-            "name": "Body",
+            "description": "A Posture Check update object",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -20223,8 +20239,8 @@ func init() {
         "operationId": "patchPostureCheck",
         "parameters": [
           {
-            "description": "A Posture Checks patch object",
-            "name": "Body",
+            "description": "A Posture Check patch object",
+            "name": "postureCheck",
             "in": "body",
             "required": true,
             "schema": {
@@ -20354,7 +20370,7 @@ func init() {
         "parameters": [
           {
             "description": "A Posture Response",
-            "name": "Body",
+            "name": "postureResponse",
             "in": "body",
             "required": true,
             "schema": {
@@ -20449,7 +20465,7 @@ func init() {
         "parameters": [
           {
             "description": "A Posture Response",
-            "name": "Body",
+            "name": "postureResponse",
             "in": "body",
             "required": true,
             "schema": {
@@ -20627,7 +20643,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -20793,7 +20809,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -21019,7 +21035,7 @@ func init() {
         "parameters": [
           {
             "description": "A service edge router policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -21375,7 +21391,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy to create",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -21541,7 +21557,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy update object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -21767,7 +21783,7 @@ func init() {
         "parameters": [
           {
             "description": "A service policy patch object",
-            "name": "Body",
+            "name": "policy",
             "in": "body",
             "required": true,
             "schema": {
@@ -22334,7 +22350,7 @@ func init() {
         "parameters": [
           {
             "description": "A service to create",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -22500,7 +22516,7 @@ func init() {
         "parameters": [
           {
             "description": "A service update object",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -22726,7 +22742,7 @@ func init() {
         "parameters": [
           {
             "description": "A service patch object",
-            "name": "Body",
+            "name": "service",
             "in": "body",
             "required": true,
             "schema": {
@@ -23356,7 +23372,7 @@ func init() {
         "parameters": [
           {
             "description": "A session to create",
-            "name": "Body",
+            "name": "session",
             "in": "body",
             "required": true,
             "schema": {
@@ -23828,7 +23844,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator to create",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -23994,7 +24010,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator update object",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -24220,7 +24236,7 @@ func init() {
         "parameters": [
           {
             "description": "A terminator patch object",
-            "name": "Body",
+            "name": "terminator",
             "in": "body",
             "required": true,
             "schema": {
@@ -24412,7 +24428,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router to create",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {
@@ -24578,7 +24594,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router update object",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {
@@ -24804,7 +24820,7 @@ func init() {
         "parameters": [
           {
             "description": "A transit router patch object",
-            "name": "Body",
+            "name": "router",
             "in": "body",
             "required": true,
             "schema": {

--- a/rest_server/operations/authentication/authenticate_mfa_parameters.go
+++ b/rest_server/operations/authentication/authenticate_mfa_parameters.go
@@ -60,7 +60,7 @@ type AuthenticateMfaParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.MfaCode
+	MfaAuth *rest_model.MfaCode
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *AuthenticateMfaParams) BindRequest(r *http.Request, route *middleware.M
 		var body rest_model.MfaCode
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("mfaAuth", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("mfaAuth", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *AuthenticateMfaParams) BindRequest(r *http.Request, route *middleware.M
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.MfaAuth = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("mfaAuth", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/authentication/authenticate_parameters.go
+++ b/rest_server/operations/authentication/authenticate_parameters.go
@@ -60,7 +60,7 @@ type AuthenticateParams struct {
 	/*
 	  In: body
 	*/
-	Body *rest_model.Authenticate
+	Auth *rest_model.Authenticate
 	/*
 	  Required: true
 	  In: query
@@ -83,7 +83,7 @@ func (o *AuthenticateParams) BindRequest(r *http.Request, route *middleware.Matc
 		defer r.Body.Close()
 		var body rest_model.Authenticate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			res = append(res, errors.NewParseError("body", "body", "", err))
+			res = append(res, errors.NewParseError("auth", "body", "", err))
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
@@ -91,7 +91,7 @@ func (o *AuthenticateParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Auth = &body
 			}
 		}
 	}

--- a/rest_server/operations/authenticator/create_authenticator_parameters.go
+++ b/rest_server/operations/authenticator/create_authenticator_parameters.go
@@ -56,11 +56,11 @@ type CreateAuthenticatorParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A Authenticators create object
+	/*A Authenticator create object
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.AuthenticatorCreate
+	Authenticator *rest_model.AuthenticatorCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateAuthenticatorParams) BindRequest(r *http.Request, route *middlewa
 		var body rest_model.AuthenticatorCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("authenticator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("authenticator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateAuthenticatorParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Authenticator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("authenticator", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/authenticator/patch_authenticator_parameters.go
+++ b/rest_server/operations/authenticator/patch_authenticator_parameters.go
@@ -61,7 +61,7 @@ type PatchAuthenticatorParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.AuthenticatorPatch
+	Authenticator *rest_model.AuthenticatorPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchAuthenticatorParams) BindRequest(r *http.Request, route *middlewar
 		var body rest_model.AuthenticatorPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("authenticator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("authenticator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchAuthenticatorParams) BindRequest(r *http.Request, route *middlewar
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Authenticator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("authenticator", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/authenticator/update_authenticator_parameters.go
+++ b/rest_server/operations/authenticator/update_authenticator_parameters.go
@@ -61,7 +61,7 @@ type UpdateAuthenticatorParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.AuthenticatorUpdate
+	Authenticator *rest_model.AuthenticatorUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateAuthenticatorParams) BindRequest(r *http.Request, route *middlewa
 		var body rest_model.AuthenticatorUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("authenticator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("authenticator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateAuthenticatorParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Authenticator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("authenticator", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/certificate_authority/create_ca_parameters.go
+++ b/rest_server/operations/certificate_authority/create_ca_parameters.go
@@ -60,7 +60,7 @@ type CreateCaParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.CaCreate
+	Ca *rest_model.CaCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateCaParams) BindRequest(r *http.Request, route *middleware.MatchedR
 		var body rest_model.CaCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("ca", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("ca", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateCaParams) BindRequest(r *http.Request, route *middleware.MatchedR
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Ca = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("ca", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/certificate_authority/patch_ca_parameters.go
+++ b/rest_server/operations/certificate_authority/patch_ca_parameters.go
@@ -61,7 +61,7 @@ type PatchCaParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.CaPatch
+	Ca *rest_model.CaPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchCaParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 		var body rest_model.CaPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("ca", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("ca", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchCaParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Ca = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("ca", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/certificate_authority/update_ca_parameters.go
+++ b/rest_server/operations/certificate_authority/update_ca_parameters.go
@@ -61,7 +61,7 @@ type UpdateCaParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.CaUpdate
+	Ca *rest_model.CaUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateCaParams) BindRequest(r *http.Request, route *middleware.MatchedR
 		var body rest_model.CaUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("ca", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("ca", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateCaParams) BindRequest(r *http.Request, route *middleware.MatchedR
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Ca = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("ca", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/config/create_config_parameters.go
+++ b/rest_server/operations/config/create_config_parameters.go
@@ -60,7 +60,7 @@ type CreateConfigParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigCreate
+	Config *rest_model.ConfigCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateConfigParams) BindRequest(r *http.Request, route *middleware.Matc
 		var body rest_model.ConfigCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("config", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("config", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateConfigParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Config = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("config", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/config/create_config_type_parameters.go
+++ b/rest_server/operations/config/create_config_type_parameters.go
@@ -60,7 +60,7 @@ type CreateConfigTypeParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigTypeCreate
+	ConfigType *rest_model.ConfigTypeCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateConfigTypeParams) BindRequest(r *http.Request, route *middleware.
 		var body rest_model.ConfigTypeCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("configType", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("configType", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateConfigTypeParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.ConfigType = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("configType", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/config/patch_config_parameters.go
+++ b/rest_server/operations/config/patch_config_parameters.go
@@ -61,7 +61,7 @@ type PatchConfigParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigPatch
+	Config *rest_model.ConfigPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchConfigParams) BindRequest(r *http.Request, route *middleware.Match
 		var body rest_model.ConfigPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("config", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("config", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchConfigParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Config = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("config", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/config/patch_config_type_parameters.go
+++ b/rest_server/operations/config/patch_config_type_parameters.go
@@ -61,7 +61,7 @@ type PatchConfigTypeParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigTypePatch
+	ConfigType *rest_model.ConfigTypePatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchConfigTypeParams) BindRequest(r *http.Request, route *middleware.M
 		var body rest_model.ConfigTypePatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("configType", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("configType", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchConfigTypeParams) BindRequest(r *http.Request, route *middleware.M
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.ConfigType = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("configType", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/config/update_config_parameters.go
+++ b/rest_server/operations/config/update_config_parameters.go
@@ -61,7 +61,7 @@ type UpdateConfigParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigUpdate
+	Config *rest_model.ConfigUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateConfigParams) BindRequest(r *http.Request, route *middleware.Matc
 		var body rest_model.ConfigUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("config", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("config", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateConfigParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Config = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("config", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/config/update_config_type_parameters.go
+++ b/rest_server/operations/config/update_config_type_parameters.go
@@ -61,7 +61,7 @@ type UpdateConfigTypeParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ConfigTypeUpdate
+	ConfigType *rest_model.ConfigTypeUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateConfigTypeParams) BindRequest(r *http.Request, route *middleware.
 		var body rest_model.ConfigTypeUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("configType", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("configType", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateConfigTypeParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.ConfigType = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("configType", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/current_api_session/create_current_api_session_certificate_parameters.go
+++ b/rest_server/operations/current_api_session/create_current_api_session_certificate_parameters.go
@@ -60,7 +60,7 @@ type CreateCurrentAPISessionCertificateParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.CurrentAPISessionCertificateCreate
+	SessionCertificate *rest_model.CurrentAPISessionCertificateCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateCurrentAPISessionCertificateParams) BindRequest(r *http.Request, 
 		var body rest_model.CurrentAPISessionCertificateCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("sessionCertificate", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("sessionCertificate", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateCurrentAPISessionCertificateParams) BindRequest(r *http.Request, 
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.SessionCertificate = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("sessionCertificate", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/current_api_session/patch_current_identity_authenticator_parameters.go
+++ b/rest_server/operations/current_api_session/patch_current_identity_authenticator_parameters.go
@@ -61,7 +61,7 @@ type PatchCurrentIdentityAuthenticatorParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.AuthenticatorPatchWithCurrent
+	Authenticator *rest_model.AuthenticatorPatchWithCurrent
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchCurrentIdentityAuthenticatorParams) BindRequest(r *http.Request, r
 		var body rest_model.AuthenticatorPatchWithCurrent
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("authenticator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("authenticator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchCurrentIdentityAuthenticatorParams) BindRequest(r *http.Request, r
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Authenticator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("authenticator", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/current_api_session/update_current_identity_authenticator_parameters.go
+++ b/rest_server/operations/current_api_session/update_current_identity_authenticator_parameters.go
@@ -61,7 +61,7 @@ type UpdateCurrentIdentityAuthenticatorParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.AuthenticatorUpdateWithCurrent
+	Authenticator *rest_model.AuthenticatorUpdateWithCurrent
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateCurrentIdentityAuthenticatorParams) BindRequest(r *http.Request, 
 		var body rest_model.AuthenticatorUpdateWithCurrent
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("authenticator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("authenticator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateCurrentIdentityAuthenticatorParams) BindRequest(r *http.Request, 
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Authenticator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("authenticator", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/current_identity/create_mfa_recovery_codes_parameters.go
+++ b/rest_server/operations/current_identity/create_mfa_recovery_codes_parameters.go
@@ -60,7 +60,7 @@ type CreateMfaRecoveryCodesParams struct {
 	  Required: true
 	  In: body
 	*/
-	MfaCode *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateMfaRecoveryCodesParams) BindRequest(r *http.Request, route *middl
 		var body rest_model.MfaCode
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("mfaCode", "body", ""))
+				res = append(res, errors.Required("mfaValidation", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("mfaCode", "body", "", err))
+				res = append(res, errors.NewParseError("mfaValidation", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateMfaRecoveryCodesParams) BindRequest(r *http.Request, route *middl
 			}
 
 			if len(res) == 0 {
-				o.MfaCode = &body
+				o.MfaValidation = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("mfaCode", "body", ""))
+		res = append(res, errors.Required("mfaValidation", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/current_identity/detail_mfa_recovery_codes_parameters.go
+++ b/rest_server/operations/current_identity/detail_mfa_recovery_codes_parameters.go
@@ -30,12 +30,12 @@ package current_identity
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/openziti/edge/rest_model"
 )
@@ -56,11 +56,14 @@ type DetailMfaRecoveryCodesParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*
+	  In: header
+	*/
+	MfaValidationCode *string
 	/*An MFA validation request
-	  Required: true
 	  In: body
 	*/
-	Body *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -72,15 +75,15 @@ func (o *DetailMfaRecoveryCodesParams) BindRequest(r *http.Request, route *middl
 
 	o.HTTPRequest = r
 
+	if err := o.bindMfaValidationCode(r.Header[http.CanonicalHeaderKey("mfa-validation-code")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.MfaCode
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
-			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
-			}
+			res = append(res, errors.NewParseError("mfaValidation", "body", "", err))
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
@@ -88,14 +91,30 @@ func (o *DetailMfaRecoveryCodesParams) BindRequest(r *http.Request, route *middl
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.MfaValidation = &body
 			}
 		}
-	} else {
-		res = append(res, errors.Required("body", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindMfaValidationCode binds and validates parameter MfaValidationCode from header.
+func (o *DetailMfaRecoveryCodesParams) bindMfaValidationCode(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.MfaValidationCode = &raw
+
 	return nil
 }

--- a/rest_server/operations/current_identity/verify_mfa_parameters.go
+++ b/rest_server/operations/current_identity/verify_mfa_parameters.go
@@ -60,7 +60,7 @@ type VerifyMfaParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.MfaCode
+	MfaValidation *rest_model.MfaCode
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *VerifyMfaParams) BindRequest(r *http.Request, route *middleware.Matched
 		var body rest_model.MfaCode
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("mfaValidation", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("mfaValidation", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *VerifyMfaParams) BindRequest(r *http.Request, route *middleware.Matched
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.MfaValidation = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("mfaValidation", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/edge_router/create_edge_router_parameters.go
+++ b/rest_server/operations/edge_router/create_edge_router_parameters.go
@@ -56,11 +56,11 @@ type CreateEdgeRouterParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A config-type to create
+	/*A edge router to create
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.EdgeRouterCreate
+	EdgeRouter *rest_model.EdgeRouterCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateEdgeRouterParams) BindRequest(r *http.Request, route *middleware.
 		var body rest_model.EdgeRouterCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("edgeRouter", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("edgeRouter", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateEdgeRouterParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.EdgeRouter = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("edgeRouter", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/edge_router/patch_edge_router_parameters.go
+++ b/rest_server/operations/edge_router/patch_edge_router_parameters.go
@@ -61,7 +61,7 @@ type PatchEdgeRouterParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.EdgeRouterPatch
+	EdgeRouter *rest_model.EdgeRouterPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *PatchEdgeRouterParams) BindRequest(r *http.Request, route *middleware.M
 		var body rest_model.EdgeRouterPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("edgeRouter", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("edgeRouter", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *PatchEdgeRouterParams) BindRequest(r *http.Request, route *middleware.M
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.EdgeRouter = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("edgeRouter", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/edge_router/update_edge_router_parameters.go
+++ b/rest_server/operations/edge_router/update_edge_router_parameters.go
@@ -61,7 +61,7 @@ type UpdateEdgeRouterParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.EdgeRouterUpdate
+	EdgeRouter *rest_model.EdgeRouterUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
@@ -83,9 +83,9 @@ func (o *UpdateEdgeRouterParams) BindRequest(r *http.Request, route *middleware.
 		var body rest_model.EdgeRouterUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("edgeRouter", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("edgeRouter", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,11 +94,11 @@ func (o *UpdateEdgeRouterParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.EdgeRouter = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("edgeRouter", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {

--- a/rest_server/operations/edge_router_policy/create_edge_router_policy_parameters.go
+++ b/rest_server/operations/edge_router_policy/create_edge_router_policy_parameters.go
@@ -60,7 +60,7 @@ type CreateEdgeRouterPolicyParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.EdgeRouterPolicyCreate
+	Policy *rest_model.EdgeRouterPolicyCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middl
 		var body rest_model.EdgeRouterPolicyCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middl
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/edge_router_policy/patch_edge_router_policy_parameters.go
+++ b/rest_server/operations/edge_router_policy/patch_edge_router_policy_parameters.go
@@ -57,16 +57,16 @@ type PatchEdgeRouterPolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An edge router policy patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.EdgeRouterPolicyPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*An edge router policy patch object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.EdgeRouterPolicyPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middle
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.EdgeRouterPolicyPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middle
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/edge_router_policy/update_edge_router_policy_parameters.go
+++ b/rest_server/operations/edge_router_policy/update_edge_router_policy_parameters.go
@@ -57,16 +57,16 @@ type UpdateEdgeRouterPolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An edge router policy update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.EdgeRouterPolicyUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*An edge router policy update object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.EdgeRouterPolicyUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middl
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.EdgeRouterPolicyUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateEdgeRouterPolicyParams) BindRequest(r *http.Request, route *middl
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/identity/associate_identitys_service_configs_parameters.go
+++ b/rest_server/operations/identity/associate_identitys_service_configs_parameters.go
@@ -57,16 +57,16 @@ type AssociateIdentitysServiceConfigsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An identity patch object
-	  Required: true
-	  In: body
-	*/
-	Body rest_model.ServiceConfigsAssignList
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service config patch object
+	  Required: true
+	  In: body
+	*/
+	ServiceConfigs rest_model.ServiceConfigsAssignList
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *AssociateIdentitysServiceConfigsParams) BindRequest(r *http.Request, ro
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServiceConfigsAssignList
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("serviceConfigs", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("serviceConfigs", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *AssociateIdentitysServiceConfigsParams) BindRequest(r *http.Request, ro
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.ServiceConfigs = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("serviceConfigs", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/identity/create_identity_parameters.go
+++ b/rest_server/operations/identity/create_identity_parameters.go
@@ -60,7 +60,7 @@ type CreateIdentityParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.IdentityCreate
+	Identity *rest_model.IdentityCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateIdentityParams) BindRequest(r *http.Request, route *middleware.Ma
 		var body rest_model.IdentityCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("identity", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("identity", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateIdentityParams) BindRequest(r *http.Request, route *middleware.Ma
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Identity = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("identity", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/identity/disassociate_identitys_service_configs_parameters.go
+++ b/rest_server/operations/identity/disassociate_identitys_service_configs_parameters.go
@@ -56,15 +56,15 @@ type DisassociateIdentitysServiceConfigsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An array of service and config id pairs to remove
-	  In: body
-	*/
-	Body rest_model.ServiceConfigsAssignList
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*An array of service and config id pairs to remove
+	  In: body
+	*/
+	ServiceConfigIDPairs rest_model.ServiceConfigsAssignList
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -76,11 +76,16 @@ func (o *DisassociateIdentitysServiceConfigsParams) BindRequest(r *http.Request,
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServiceConfigsAssignList
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			res = append(res, errors.NewParseError("body", "body", "", err))
+			res = append(res, errors.NewParseError("serviceConfigIdPairs", "body", "", err))
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
@@ -88,15 +93,10 @@ func (o *DisassociateIdentitysServiceConfigsParams) BindRequest(r *http.Request,
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.ServiceConfigIDPairs = body
 			}
 		}
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/identity/patch_identity_parameters.go
+++ b/rest_server/operations/identity/patch_identity_parameters.go
@@ -57,16 +57,16 @@ type PatchIdentityParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An identity patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.IdentityPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*An identity patch object
+	  Required: true
+	  In: body
+	*/
+	Identity *rest_model.IdentityPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchIdentityParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.IdentityPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("identity", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("identity", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchIdentityParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Identity = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("identity", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/identity/update_identity_parameters.go
+++ b/rest_server/operations/identity/update_identity_parameters.go
@@ -57,16 +57,16 @@ type UpdateIdentityParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*An identity update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.IdentityUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*An identity update object
+	  Required: true
+	  In: body
+	*/
+	Identity *rest_model.IdentityUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateIdentityParams) BindRequest(r *http.Request, route *middleware.Ma
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.IdentityUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("identity", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("identity", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateIdentityParams) BindRequest(r *http.Request, route *middleware.Ma
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Identity = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("identity", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/posture_checks/create_posture_check_parameters.go
+++ b/rest_server/operations/posture_checks/create_posture_check_parameters.go
@@ -56,11 +56,11 @@ type CreatePostureCheckParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A Posture Checks to create
+	/*A Posture Check to create
 	  Required: true
 	  In: body
 	*/
-	Body rest_model.PostureCheckCreate
+	PostureCheck rest_model.PostureCheckCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,7 +77,7 @@ func (o *CreatePostureCheckParams) BindRequest(r *http.Request, route *middlewar
 		body, err := rest_model.UnmarshalPostureCheckCreate(r.Body, route.Consumer)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.Required("Body", "body", "")
+				err = errors.Required("postureCheck", "body", "")
 			}
 			res = append(res, err)
 		} else {
@@ -87,11 +87,11 @@ func (o *CreatePostureCheckParams) BindRequest(r *http.Request, route *middlewar
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.PostureCheck = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("postureCheck", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/posture_checks/create_posture_response_bulk_parameters.go
+++ b/rest_server/operations/posture_checks/create_posture_response_bulk_parameters.go
@@ -60,7 +60,7 @@ type CreatePostureResponseBulkParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body []rest_model.PostureResponseCreate
+	PostureResponse []rest_model.PostureResponseCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,7 +77,7 @@ func (o *CreatePostureResponseBulkParams) BindRequest(r *http.Request, route *mi
 		body, err := rest_model.UnmarshalPostureResponseCreateSlice(r.Body, route.Consumer)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.Required("Body", "body", "")
+				err = errors.Required("postureResponse", "body", "")
 			}
 			res = append(res, err)
 		} else {
@@ -89,11 +89,11 @@ func (o *CreatePostureResponseBulkParams) BindRequest(r *http.Request, route *mi
 				}
 			}
 			if len(res) == 0 {
-				o.Body = body
+				o.PostureResponse = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("postureResponse", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/posture_checks/create_posture_response_parameters.go
+++ b/rest_server/operations/posture_checks/create_posture_response_parameters.go
@@ -60,7 +60,7 @@ type CreatePostureResponseParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body rest_model.PostureResponseCreate
+	PostureResponse rest_model.PostureResponseCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,7 +77,7 @@ func (o *CreatePostureResponseParams) BindRequest(r *http.Request, route *middle
 		body, err := rest_model.UnmarshalPostureResponseCreate(r.Body, route.Consumer)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.Required("Body", "body", "")
+				err = errors.Required("postureResponse", "body", "")
 			}
 			res = append(res, err)
 		} else {
@@ -87,11 +87,11 @@ func (o *CreatePostureResponseParams) BindRequest(r *http.Request, route *middle
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.PostureResponse = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("postureResponse", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/posture_checks/patch_posture_check_parameters.go
+++ b/rest_server/operations/posture_checks/patch_posture_check_parameters.go
@@ -57,16 +57,16 @@ type PatchPostureCheckParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A Posture Checks patch object
-	  Required: true
-	  In: body
-	*/
-	Body rest_model.PostureCheckPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A Posture Check patch object
+	  Required: true
+	  In: body
+	*/
+	PostureCheck rest_model.PostureCheckPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,12 +78,17 @@ func (o *PatchPostureCheckParams) BindRequest(r *http.Request, route *middleware
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		body, err := rest_model.UnmarshalPostureCheckPatch(r.Body, route.Consumer)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.Required("Body", "body", "")
+				err = errors.Required("postureCheck", "body", "")
 			}
 			res = append(res, err)
 		} else {
@@ -93,17 +98,12 @@ func (o *PatchPostureCheckParams) BindRequest(r *http.Request, route *middleware
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.PostureCheck = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("postureCheck", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/posture_checks/update_posture_check_parameters.go
+++ b/rest_server/operations/posture_checks/update_posture_check_parameters.go
@@ -57,16 +57,16 @@ type UpdatePostureCheckParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A Posture Checks update object
-	  Required: true
-	  In: body
-	*/
-	Body rest_model.PostureCheckUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A Posture Check update object
+	  Required: true
+	  In: body
+	*/
+	PostureCheck rest_model.PostureCheckUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,12 +78,17 @@ func (o *UpdatePostureCheckParams) BindRequest(r *http.Request, route *middlewar
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		body, err := rest_model.UnmarshalPostureCheckUpdate(r.Body, route.Consumer)
 		if err != nil {
 			if err == io.EOF {
-				err = errors.Required("Body", "body", "")
+				err = errors.Required("postureCheck", "body", "")
 			}
 			res = append(res, err)
 		} else {
@@ -93,17 +98,12 @@ func (o *UpdatePostureCheckParams) BindRequest(r *http.Request, route *middlewar
 			}
 
 			if len(res) == 0 {
-				o.Body = body
+				o.PostureCheck = body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("postureCheck", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service/create_service_parameters.go
+++ b/rest_server/operations/service/create_service_parameters.go
@@ -60,7 +60,7 @@ type CreateServiceParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ServiceCreate
+	Service *rest_model.ServiceCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateServiceParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body rest_model.ServiceCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("service", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("service", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateServiceParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Service = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("service", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/service/patch_service_parameters.go
+++ b/rest_server/operations/service/patch_service_parameters.go
@@ -57,16 +57,16 @@ type PatchServiceParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServicePatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service patch object
+	  Required: true
+	  In: body
+	*/
+	Service *rest_model.ServicePatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchServiceParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServicePatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("service", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("service", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchServiceParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Service = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("service", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service/update_service_parameters.go
+++ b/rest_server/operations/service/update_service_parameters.go
@@ -57,16 +57,16 @@ type UpdateServiceParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServiceUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service update object
+	  Required: true
+	  In: body
+	*/
+	Service *rest_model.ServiceUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateServiceParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServiceUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("service", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("service", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateServiceParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Service = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("service", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service_edge_router_policy/create_service_edge_router_policy_parameters.go
+++ b/rest_server/operations/service_edge_router_policy/create_service_edge_router_policy_parameters.go
@@ -60,7 +60,7 @@ type CreateServiceEdgeRouterPolicyParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ServiceEdgeRouterPolicyCreate
+	Policy *rest_model.ServiceEdgeRouterPolicyCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route
 		var body rest_model.ServiceEdgeRouterPolicyCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/service_edge_router_policy/patch_service_edge_router_policy_parameters.go
+++ b/rest_server/operations/service_edge_router_policy/patch_service_edge_router_policy_parameters.go
@@ -57,16 +57,16 @@ type PatchServiceEdgeRouterPolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service edge router policy patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServiceEdgeRouterPolicyPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service edge router policy patch object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.ServiceEdgeRouterPolicyPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route 
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServiceEdgeRouterPolicyPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route 
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service_edge_router_policy/update_service_edge_router_policy_parameters.go
+++ b/rest_server/operations/service_edge_router_policy/update_service_edge_router_policy_parameters.go
@@ -57,16 +57,16 @@ type UpdateServiceEdgeRouterPolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service edge router policy update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServiceEdgeRouterPolicyUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service edge router policy update object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.ServiceEdgeRouterPolicyUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServiceEdgeRouterPolicyUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateServiceEdgeRouterPolicyParams) BindRequest(r *http.Request, route
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service_policy/create_service_policy_parameters.go
+++ b/rest_server/operations/service_policy/create_service_policy_parameters.go
@@ -60,7 +60,7 @@ type CreateServicePolicyParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.ServicePolicyCreate
+	Policy *rest_model.ServicePolicyCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateServicePolicyParams) BindRequest(r *http.Request, route *middlewa
 		var body rest_model.ServicePolicyCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateServicePolicyParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/service_policy/patch_service_policy_parameters.go
+++ b/rest_server/operations/service_policy/patch_service_policy_parameters.go
@@ -57,16 +57,16 @@ type PatchServicePolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service policy patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServicePolicyPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service policy patch object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.ServicePolicyPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchServicePolicyParams) BindRequest(r *http.Request, route *middlewar
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServicePolicyPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchServicePolicyParams) BindRequest(r *http.Request, route *middlewar
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/service_policy/update_service_policy_parameters.go
+++ b/rest_server/operations/service_policy/update_service_policy_parameters.go
@@ -57,16 +57,16 @@ type UpdateServicePolicyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A service policy update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.ServicePolicyUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A service policy update object
+	  Required: true
+	  In: body
+	*/
+	Policy *rest_model.ServicePolicyUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateServicePolicyParams) BindRequest(r *http.Request, route *middlewa
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.ServicePolicyUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("policy", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("policy", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateServicePolicyParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Policy = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("policy", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/session/create_session_parameters.go
+++ b/rest_server/operations/session/create_session_parameters.go
@@ -60,7 +60,7 @@ type CreateSessionParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.SessionCreate
+	Session *rest_model.SessionCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateSessionParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body rest_model.SessionCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("session", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("session", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateSessionParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Session = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("session", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/terminator/create_terminator_parameters.go
+++ b/rest_server/operations/terminator/create_terminator_parameters.go
@@ -60,7 +60,7 @@ type CreateTerminatorParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.TerminatorCreate
+	Terminator *rest_model.TerminatorCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateTerminatorParams) BindRequest(r *http.Request, route *middleware.
 		var body rest_model.TerminatorCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("terminator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("terminator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateTerminatorParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Terminator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("terminator", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/terminator/patch_terminator_parameters.go
+++ b/rest_server/operations/terminator/patch_terminator_parameters.go
@@ -57,16 +57,16 @@ type PatchTerminatorParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A terminator patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.TerminatorPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A terminator patch object
+	  Required: true
+	  In: body
+	*/
+	Terminator *rest_model.TerminatorPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchTerminatorParams) BindRequest(r *http.Request, route *middleware.M
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.TerminatorPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("terminator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("terminator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchTerminatorParams) BindRequest(r *http.Request, route *middleware.M
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Terminator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("terminator", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/terminator/update_terminator_parameters.go
+++ b/rest_server/operations/terminator/update_terminator_parameters.go
@@ -57,16 +57,16 @@ type UpdateTerminatorParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A terminator update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.TerminatorUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A terminator update object
+	  Required: true
+	  In: body
+	*/
+	Terminator *rest_model.TerminatorUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateTerminatorParams) BindRequest(r *http.Request, route *middleware.
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.TerminatorUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("terminator", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("terminator", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateTerminatorParams) BindRequest(r *http.Request, route *middleware.
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Terminator = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("terminator", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/transit_router/create_transit_router_parameters.go
+++ b/rest_server/operations/transit_router/create_transit_router_parameters.go
@@ -60,7 +60,7 @@ type CreateTransitRouterParams struct {
 	  Required: true
 	  In: body
 	*/
-	Body *rest_model.TransitRouterCreate
+	Router *rest_model.TransitRouterCreate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,9 +77,9 @@ func (o *CreateTransitRouterParams) BindRequest(r *http.Request, route *middlewa
 		var body rest_model.TransitRouterCreate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("router", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("router", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -88,11 +88,11 @@ func (o *CreateTransitRouterParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Router = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("router", "body", ""))
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/rest_server/operations/transit_router/patch_transit_router_parameters.go
+++ b/rest_server/operations/transit_router/patch_transit_router_parameters.go
@@ -57,16 +57,16 @@ type PatchTransitRouterParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A transit router patch object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.TransitRouterPatch
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A transit router patch object
+	  Required: true
+	  In: body
+	*/
+	Router *rest_model.TransitRouterPatch
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *PatchTransitRouterParams) BindRequest(r *http.Request, route *middlewar
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.TransitRouterPatch
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("router", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("router", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *PatchTransitRouterParams) BindRequest(r *http.Request, route *middlewar
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Router = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("router", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/rest_server/operations/transit_router/update_transit_router_parameters.go
+++ b/rest_server/operations/transit_router/update_transit_router_parameters.go
@@ -57,16 +57,16 @@ type UpdateTransitRouterParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A transit router update object
-	  Required: true
-	  In: body
-	*/
-	Body *rest_model.TransitRouterUpdate
 	/*The id of the requested resource
 	  Required: true
 	  In: path
 	*/
 	ID string
+	/*A transit router update object
+	  Required: true
+	  In: body
+	*/
+	Router *rest_model.TransitRouterUpdate
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -78,14 +78,19 @@ func (o *UpdateTransitRouterParams) BindRequest(r *http.Request, route *middlewa
 
 	o.HTTPRequest = r
 
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
 		var body rest_model.TransitRouterUpdate
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("body", "body", ""))
+				res = append(res, errors.Required("router", "body", ""))
 			} else {
-				res = append(res, errors.NewParseError("body", "body", "", err))
+				res = append(res, errors.NewParseError("router", "body", "", err))
 			}
 		} else {
 			// validate body object
@@ -94,17 +99,12 @@ func (o *UpdateTransitRouterParams) BindRequest(r *http.Request, route *middlewa
 			}
 
 			if len(res) == 0 {
-				o.Body = &body
+				o.Router = &body
 			}
 		}
 	} else {
-		res = append(res, errors.Required("body", "body", ""))
+		res = append(res, errors.Required("router", "body", ""))
 	}
-	rID, rhkID, _ := route.Params.GetOK("id")
-	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -269,7 +269,7 @@ paths:
         - Authentication
       operationId: authenticate
       parameters:
-        - name: Body
+        - name: auth
           in: body
           required: false
           schema:
@@ -293,7 +293,7 @@ paths:
         - MFA
       operationId: authenticateMfa
       parameters:
-        - name: Body
+        - name: mfaAuth
           in: body
           required: true
           description: 'An MFA validation request'
@@ -332,10 +332,10 @@ paths:
         - Authenticator
       operationId: createAuthenticator
       parameters:
-        - name: Body
+        - name: authenticator
           in: body
           required: true
-          description: A Authenticators create object
+          description: A Authenticator create object
           schema:
             $ref: '#/definitions/authenticatorCreate'
       responses:
@@ -374,7 +374,7 @@ paths:
         - Authenticator
       operationId: updateAuthenticator
       parameters:
-        - name: Body
+        - name: authenticator
           in: body
           required: true
           description: 'An authenticator put object'
@@ -398,7 +398,7 @@ paths:
         - Authenticator
       operationId: patchAuthenticator
       parameters:
-        - name: Body
+        - name: authenticator
           in: body
           required: true
           description: An authenticator patch object
@@ -460,7 +460,7 @@ paths:
       operationId: createCa
 
       parameters:
-        - name: Body
+        - name: ca
           in: body
           required: true
           description: A CA to create
@@ -500,7 +500,7 @@ paths:
         - Certificate Authority
       operationId: updateCa
       parameters:
-        - name: Body
+        - name: ca
           in: body
           required: true
           description: A CA update object
@@ -524,7 +524,7 @@ paths:
         - Certificate Authority
       operationId: patchCa
       parameters:
-        - name: Body
+        - name: ca
           in: body
           required: true
           description: A CA patch object
@@ -646,7 +646,7 @@ paths:
         - Config
       operationId: createConfigType
       parameters:
-        - name: Body
+        - name: configType
           in: body
           required: true
           description: A config-type to create
@@ -686,7 +686,7 @@ paths:
         - Config
       operationId: updateConfigType
       parameters:
-        - name: Body
+        - name: configType
           in: body
           required: true
           description: A config-type update object
@@ -710,7 +710,7 @@ paths:
         - Config
       operationId: patchConfigType
       parameters:
-        - name: Body
+        - name: configType
           in: body
           required: true
           description: A config-type patch object
@@ -787,7 +787,7 @@ paths:
         - Config
       operationId: createConfig
       parameters:
-        - name: Body
+        - name: config
           in: body
           required: true
           description: A config to create
@@ -827,7 +827,7 @@ paths:
         - Config
       operationId: updateConfig
       parameters:
-        - name: Body
+        - name: config
           in: body
           required: true
           description: A config update object
@@ -851,7 +851,7 @@ paths:
         - Config
       operationId: patchConfig
       parameters:
-        - name: Body
+        - name: config
           in: body
           required: true
           description: A config patch object
@@ -940,7 +940,7 @@ paths:
         - Current API Session
       operationId: createCurrentApiSessionCertificate
       parameters:
-        - name: Body
+        - name: sessionCertificate
           in: body
           required: true
           description: The payload describing the CSR used to create a session certificate
@@ -1089,12 +1089,16 @@ paths:
         - MFA
       operationId: deleteMfa
       parameters:
-        - name: Body
+        - name: mfaValidation
           in: body
-          required: true
+          required: false
           description: 'An MFA validation request'
           schema:
             $ref: '#/definitions/mfaCode'
+        - name: mfa-validation-code
+          in: header
+          required: false
+          type: string
       responses:
         '200':
           $ref: '#/responses/emptyResponse'
@@ -1135,7 +1139,7 @@ paths:
         - MFA
       operationId: verifyMfa
       parameters:
-        - name: Body
+        - name: mfaValidation
           in: body
           required: true
           description: 'An MFA validation request'
@@ -1161,12 +1165,16 @@ paths:
         - MFA
       operationId: detailMfaRecoveryCodes
       parameters:
-        - name: Body
+        - name: mfaValidation
           in: body
-          required: true
+          required: false
           description: 'An MFA validation request'
           schema:
             $ref: '#/definitions/mfaCode'
+        - name: mfa-validation-code
+          in: header
+          required: false
+          type: string
       responses:
         '200':
           $ref: '#/responses/emptyResponse'
@@ -1187,7 +1195,7 @@ paths:
         - MFA
       operationId: createMfaRecoveryCodes
       parameters:
-        - name: mfaCode
+        - name: mfaValidation
           in: body
           required: true
           description: 'An MFA validation request'
@@ -1247,7 +1255,7 @@ paths:
         - Current API Session
       operationId: updateCurrentIdentityAuthenticator
       parameters:
-        - name: Body
+        - name: authenticator
           in: body
           required: true
           description: 'An authenticator put object'
@@ -1273,7 +1281,7 @@ paths:
         - Current API Session
       operationId: patchCurrentIdentityAuthenticator
       parameters:
-        - name: Body
+        - name: authenticator
           in: body
           required: true
           description: An authenticator patch object
@@ -1320,7 +1328,7 @@ paths:
         - Edge Router Policy
       operationId: createEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: An edge router policy to create
@@ -1360,7 +1368,7 @@ paths:
         - Edge Router Policy
       operationId: updateEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: An edge router policy update object
@@ -1384,7 +1392,7 @@ paths:
         - Edge Router Policy
       operationId: patchEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: An edge router policy patch object
@@ -1487,10 +1495,10 @@ paths:
         - Edge Router
       operationId: createEdgeRouter
       parameters:
-        - name: Body
+        - name: edgeRouter
           in: body
           required: true
-          description: A config-type to create
+          description: A edge router to create
           schema:
             $ref: '#/definitions/edgeRouterCreate'
       responses:
@@ -1527,7 +1535,7 @@ paths:
         - Edge Router
       operationId: updateEdgeRouter
       parameters:
-        - name: Body
+        - name: edgeRouter
           in: body
           required: true
           description: An edge router update object
@@ -1551,7 +1559,7 @@ paths:
         - Edge Router
       operationId: patchEdgeRouter
       parameters:
-        - name: Body
+        - name: edgeRouter
           in: body
           required: true
           description: An edge router patch object
@@ -1902,7 +1910,7 @@ paths:
         - Identity
       operationId: createIdentity
       parameters:
-        - name: Body
+        - name: identity
           in: body
           required: true
           description: An identity to create
@@ -1942,7 +1950,7 @@ paths:
         - Identity
       operationId: updateIdentity
       parameters:
-        - name: Body
+        - name: identity
           in: body
           required: true
           description: An identity update object
@@ -1966,7 +1974,7 @@ paths:
         - Identity
       operationId: patchIdentity
       parameters:
-        - name: Body
+        - name: identity
           in: body
           required: true
           description: An identity patch object
@@ -2038,10 +2046,10 @@ paths:
       summary: Associate service configs for a specific identity
       description: Associate service configs to a specific identity
       parameters:
-        - name: Body
+        - name: serviceConfigs
           in: body
           required: true
-          description: An identity patch object
+          description: A service config patch object
           schema:
             $ref: '#/definitions/serviceConfigsAssignList'
       security:
@@ -2062,7 +2070,7 @@ paths:
       summary: Remove associated service configs from a specific identity
       description: Remove service configs from a specific identity
       parameters:
-        - name: Body
+        - name: serviceConfigIdPairs
           in: body
           required: false
           description: An array of service and config id pairs to remove
@@ -2275,7 +2283,7 @@ paths:
         - Service Edge Router Policy
       operationId: createServiceEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service edge router policy to create
@@ -2315,7 +2323,7 @@ paths:
         - Service Edge Router Policy
       operationId: updateServiceEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service edge router policy update object
@@ -2339,7 +2347,7 @@ paths:
         - Service Edge Router Policy
       operationId: patchServiceEdgeRouterPolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service edge router policy patch object
@@ -2439,7 +2447,7 @@ paths:
         - Service Policy
       operationId: createServicePolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service policy to create
@@ -2479,7 +2487,7 @@ paths:
         - Service Policy
       operationId: updateServicePolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service policy update object
@@ -2503,7 +2511,7 @@ paths:
         - Service Policy
       operationId: patchServicePolicy
       parameters:
-        - name: Body
+        - name: policy
           in: body
           required: true
           description: A service policy patch object
@@ -2637,7 +2645,7 @@ paths:
         - Service
       operationId: createService
       parameters:
-        - name: Body
+        - name: service
           in: body
           required: true
           description: A service to create
@@ -2677,7 +2685,7 @@ paths:
         - Service
       operationId: updateService
       parameters:
-        - name: Body
+        - name: service
           in: body
           required: true
           description: A service update object
@@ -2701,7 +2709,7 @@ paths:
         - Service
       operationId: patchService
       parameters:
-        - name: Body
+        - name: service
           in: body
           required: true
           description: A service patch object
@@ -2896,7 +2904,7 @@ paths:
         - Session
       operationId: createSession
       parameters:
-        - name: Body
+        - name: session
           in: body
           required: true
           description: A session to create
@@ -2975,7 +2983,7 @@ paths:
         - Terminator
       operationId: createTerminator
       parameters:
-        - name: Body
+        - name: terminator
           in: body
           required: true
           description: A terminator to create
@@ -3015,7 +3023,7 @@ paths:
         - Terminator
       operationId: updateTerminator
       parameters:
-        - name: Body
+        - name: terminator
           in: body
           required: true
           description: A terminator update object
@@ -3039,7 +3047,7 @@ paths:
         - Terminator
       operationId: patchTerminator
       parameters:
-        - name: Body
+        - name: terminator
           in: body
           required: true
           description: A terminator patch object
@@ -3165,7 +3173,7 @@ paths:
         - Transit Router
       operationId: createTransitRouter
       parameters:
-        - name: Body
+        - name: router
           in: body
           required: true
           description: A transit router to create
@@ -3205,7 +3213,7 @@ paths:
         - Transit Router
       operationId: updateTransitRouter
       parameters:
-        - name: Body
+        - name: router
           in: body
           required: true
           description: A transit router update object
@@ -3229,7 +3237,7 @@ paths:
         - Transit Router
       operationId: patchTransitRouter
       parameters:
-        - name: Body
+        - name: router
           in: body
           required: true
           description: A transit router patch object
@@ -3381,7 +3389,7 @@ paths:
         - Posture Checks
       operationId: createPostureResponse
       parameters:
-        - name: Body
+        - name: postureResponse
           in: body
           required: true
           description: A Posture Response
@@ -3404,7 +3412,7 @@ paths:
         - Posture Checks
       operationId: createPostureResponseBulk
       parameters:
-        - name: Body
+        - name: postureResponse
           in: body
           required: true
           description: A Posture Response
@@ -3453,10 +3461,10 @@ paths:
         - Posture Checks
       operationId: createPostureCheck
       parameters:
-        - name: Body
+        - name: postureCheck
           in: body
           required: true
-          description: A Posture Checks to create
+          description: A Posture Check to create
           schema:
             $ref: '#/definitions/PostureCheckCreate'
       responses:
@@ -3493,10 +3501,10 @@ paths:
         - Posture Checks
       operationId: updatePostureCheck
       parameters:
-        - name: Body
+        - name: postureCheck
           in: body
           required: true
-          description: A Posture Checks update object
+          description: A Posture Check update object
           schema:
             $ref: '#/definitions/PostureCheckUpdate'
       responses:
@@ -3517,10 +3525,10 @@ paths:
         - Posture Checks
       operationId: patchPostureCheck
       parameters:
-        - name: Body
+        - name: postureCheck
           in: body
           required: true
-          description: A Posture Checks patch object
+          description: A Posture Check patch object
           schema:
             $ref: '#/definitions/PostureCheckPatch'
       responses:


### PR DESCRIPTION
- swagger copy pasta was using the same parameter name for everything,
  "body", which made error messages read "error in body for body"
- parameter rename ripples into parameter property definitions
- allow mfa codes in GET and DELETE as libuv doesn't allow them to have
  bodies (-.-)