### PR TITLE
adds thread safe router state

### DIFF
--- a/controller/env/broker.go
+++ b/controller/env/broker.go
@@ -180,8 +180,8 @@ func (broker *Broker) apiSessionCertificateHandler(args ...interface{}) {
 }
 
 func (broker *Broker) IsEdgeRouterOnline(id string) bool {
-	status := broker.GetEdgeRouterState(id)
-	return status.IsOnline
+	state := broker.GetEdgeRouterState(id)
+	return state.IsOnline
 }
 
 func (broker *Broker) GetEdgeRouterState(id string) RouterStateValues {

--- a/controller/env/broker.go
+++ b/controller/env/broker.go
@@ -19,7 +19,6 @@ package env
 import (
 	"github.com/kataras/go-events"
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/edge/controller/model"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/edge/pb/edge_ctrl_pb"
 	"github.com/openziti/fabric/controller/network"
@@ -181,12 +180,12 @@ func (broker *Broker) apiSessionCertificateHandler(args ...interface{}) {
 }
 
 func (broker *Broker) IsEdgeRouterOnline(id string) bool {
-	er, _ := broker.GetOnlineEdgeRouter(id)
-	return er != nil
+	status := broker.GetEdgeRouterState(id)
+	return status.IsOnline
 }
 
-func (broker *Broker) GetOnlineEdgeRouter(id string) (*model.EdgeRouter, RouterSyncStatus) {
-	return broker.routerSyncStrategy.GetOnlineEdgeRouter(id)
+func (broker *Broker) GetEdgeRouterState(id string) RouterStateValues {
+	return broker.routerSyncStrategy.GetEdgeRouterState(id)
 }
 
 func (broker *Broker) Stop() {

--- a/controller/env/sync.go
+++ b/controller/env/sync.go
@@ -140,7 +140,15 @@ func (r *LockingRouterState) Values() RouterStateValues {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	return r.internal
+	ret := r.internal
+
+	ret.Protocols = map[string]string{}
+
+	for k, v := range r.internal.Protocols {
+		ret.Protocols[k] = v
+	}
+
+	return ret
 }
 
 func (r *LockingRouterState) SetIsOnline(isOnline bool) {

--- a/controller/env/sync.go
+++ b/controller/env/sync.go
@@ -20,6 +20,8 @@ import (
 	"github.com/openziti/edge/controller/model"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/fabric/controller/network"
+	"github.com/openziti/foundation/common"
+	"sync"
 )
 
 // Aliased type for router strategies
@@ -52,8 +54,7 @@ const (
 // any upfront state and then maintaining state after that.
 type RouterSyncStrategy interface {
 	Type() RouterSyncStrategyType
-	Status(id string) RouterSyncStatus
-	GetOnlineEdgeRouter(id string) (*model.EdgeRouter, RouterSyncStatus)
+	GetEdgeRouterState(id string) RouterStateValues
 	Stop()
 	RouterConnectionHandler
 	RouterSynchronizerEventHandler
@@ -74,4 +75,153 @@ type RouterSynchronizerEventHandler interface {
 	ApiSessionDeleted(apiSession *persistence.ApiSession)
 
 	SessionDeleted(session *persistence.Session)
+}
+
+// RouterState provides a thread save mechanism to access and set router status information that may be influx
+// due to reouter connection/disconnection.
+type RouterState interface {
+	SetIsOnline(isOnline bool)
+	IsOnline() bool
+
+	SetHostname(hostname string)
+	Hostname() string
+
+	SetProtocols(protocols map[string]string)
+	Protocols() map[string]string
+
+	SetSyncStatus(status RouterSyncStatus)
+	SyncStatus() RouterSyncStatus
+
+	SetVersionInfo(versionInfo common.VersionInfo)
+	GetVersionInfo() common.VersionInfo
+
+	Values() RouterStateValues
+}
+
+var _ RouterState = &LockingRouterState{}
+
+type RouterStateValues struct {
+	IsOnline    bool
+	Hostname    string
+	Protocols   map[string]string
+	SyncStatus  RouterSyncStatus
+	VersionInfo common.VersionInfo
+}
+
+func NewRouterStatusValues() RouterStateValues {
+	return RouterStateValues{
+		IsOnline:   false,
+		Hostname:   "",
+		Protocols:  map[string]string{},
+		SyncStatus: RouterSyncUnknown,
+		VersionInfo: common.VersionInfo{
+			Version:   "",
+			Revision:  "",
+			BuildDate: "",
+			OS:        "",
+			Arch:      "",
+		},
+	}
+}
+
+type LockingRouterState struct {
+	internal RouterStateValues
+	lock     sync.Mutex
+}
+
+func NewLockingRouterStatus() *LockingRouterState {
+	return &LockingRouterState{
+		internal: NewRouterStatusValues(),
+		lock: sync.Mutex{},
+	}
+}
+
+func (r *LockingRouterState) Values() RouterStateValues {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.internal
+}
+
+func (r *LockingRouterState) SetIsOnline(isOnline bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.internal.IsOnline = isOnline
+}
+
+func (r *LockingRouterState) IsOnline() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.internal.IsOnline
+}
+
+func (r *LockingRouterState) SetHostname(hostname string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.internal.Hostname = hostname
+}
+
+func (r *LockingRouterState) Hostname() string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.internal.Hostname
+}
+
+func (r *LockingRouterState) SetProtocols(protocols map[string]string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	newProtocols := map[string]string{}
+
+	for k, v := range protocols {
+		newProtocols[k] = v
+	}
+
+	r.internal.Protocols = newProtocols
+}
+
+func (r *LockingRouterState) Protocols() map[string]string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	//to return empty, not nil
+	copy := map[string]string{}
+
+	for k, v := range r.internal.Protocols {
+		copy[k] = v
+	}
+
+	return copy
+}
+
+func (r *LockingRouterState) SetSyncStatus(syncStatus RouterSyncStatus) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.internal.SyncStatus = syncStatus
+}
+
+func (r *LockingRouterState) SyncStatus() RouterSyncStatus {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.internal.SyncStatus
+}
+
+func (r *LockingRouterState) SetVersionInfo(versionInfo common.VersionInfo) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.internal.VersionInfo = versionInfo
+}
+
+func (r *LockingRouterState) GetVersionInfo() common.VersionInfo {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.internal.VersionInfo
 }

--- a/controller/internal/routes/current_identity_api_model.go
+++ b/controller/internal/routes/current_identity_api_model.go
@@ -162,23 +162,18 @@ func MapCurrentIdentityEdgeRouterToRestEntity(ae *env.AppEnv, _ *response.Reques
 
 func MapCurrentIdentityEdgeRouterToRestModel(ae *env.AppEnv, router *model.EdgeRouter) (*rest_model.CurrentIdentityEdgeRouterDetail, error) {
 	hostname := ""
-	protocols := map[string]string{}
-	onlineEdgeRouter, erSyncStatus := ae.Broker.GetOnlineEdgeRouter(router.Id)
-	syncStatus := string(erSyncStatus)
-	isOnline := onlineEdgeRouter != nil
 
-	if isOnline {
-		hostname = *onlineEdgeRouter.Hostname
-		protocols = onlineEdgeRouter.EdgeRouterProtocols
-	}
+	routerState := ae.Broker.GetEdgeRouterState(router.Id)
+
+	syncStatus := string(routerState.SyncStatus)
 
 	ret := &rest_model.CurrentIdentityEdgeRouterDetail{
 		BaseEntity: BaseEntityToRestModel(router, EdgeRouterLinkFactory),
 		CommonEdgeRouterProperties: rest_model.CommonEdgeRouterProperties{
 			Hostname:           &hostname,
-			IsOnline:           &isOnline,
+			IsOnline:           &routerState.IsOnline,
 			Name:               &router.Name,
-			SupportedProtocols: protocols,
+			SupportedProtocols: routerState.Protocols,
 			SyncStatus:         &syncStatus,
 		},
 	}

--- a/controller/model/api_session_handlers.go
+++ b/controller/model/api_session_handlers.go
@@ -107,7 +107,6 @@ func (handler *ApiSessionHandler) MarkActivity(tokens []string) ([]string, error
 				} else {
 					return err
 				}
-
 			}
 			if err = store.Update(mutCtx, apiSession, persistence.UpdateTimeOnlyFieldChecker{}); err != nil {
 				if err != nil {


### PR DESCRIPTION
Router state used to be stored and accessed in a thread unsafe way.
State is now locks on a mutex for setting values and values are copied
out for referencing.