### PR TITLE
on invalid token ignore err and check bool status only

### DIFF
--- a/controller/internal/routes/current_identity_router.go
+++ b/controller/internal/routes/current_identity_router.go
@@ -235,12 +235,7 @@ func (r *CurrentIdentityRouter) createMfaRecoveryCodes(ae *env.AppEnv, rc *respo
 		return
 	}
 
-	ok, err := ae.Handlers.Mfa.Verify(mfa, *body.Code)
-
-	if err != nil {
-		rc.RespondWithError(err)
-		return
-	}
+	ok, _ := ae.Handlers.Mfa.Verify(mfa, *body.Code)
 
 	if !ok {
 		rc.RespondWithError(apierror.NewInvalidMfaTokenError())

--- a/tests/mfa_ziti_test.go
+++ b/tests/mfa_ziti_test.go
@@ -527,6 +527,23 @@ func Test_MFA(t *testing.T) {
 				standardErrorJsonResponseTests(resp, apierror.MfaInvalidTokenCode, http.StatusBadRequest, t)
 			})
 
+			t.Run("create new recovery codes with empty code should return invalid token/bad request", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				resp, err := mfaValidatedSession.newAuthenticatedRequest().SetBody(newMfaCodeBody("")).Post("/current-identity/mfa/recovery-codes")
+
+				ctx.Req.NoError(err)
+				standardErrorJsonResponseTests(resp, apierror.MfaInvalidTokenCode, http.StatusBadRequest, t)
+			})
+
+			t.Run("create recovery codes with an invalid code should return invalid token/bad request", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				ctx.testContextChanged(t)
+				resp, err := mfaValidatedSession.newAuthenticatedRequest().SetBody(newMfaCodeBody("6sa5d4f56sad")).Post("/current-identity/mfa/recovery-codes")
+
+				ctx.Req.NoError(err)
+				standardErrorJsonResponseTests(resp, apierror.MfaInvalidTokenCode, http.StatusBadRequest, t)
+			})
+
 			t.Run("newly authenticated sessions", func(t *testing.T) {
 				var newValidatedSession *session
 


### PR DESCRIPTION
Prior to this submitting an invalid code to regenerate recovery codes would result in a 500 w/ a proper invalid token cause.