### PR TITLE
set mfa posture on enroll

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -473,5 +473,9 @@ func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestC
 }
 
 func (ae *AppEnv) HandleServiceEvent(event *persistence.ServiceEvent) {
-	ae.IdentityRefreshMap.Set(event.IdentityId, time.Now())
+	ae.HandleServiceUpdatedEventForIdentityId(event.IdentityId)
+}
+
+func (ae *AppEnv) HandleServiceUpdatedEventForIdentityId(identityId string) {
+	ae.IdentityRefreshMap.Set(identityId, time.Now())
 }

--- a/controller/internal/routes/api_session_api_model.go
+++ b/controller/internal/routes/api_session_api_model.go
@@ -82,9 +82,7 @@ func MapApiSessionToRestInterface(ae *env.AppEnv, _ *response.RequestContext, ap
 func MapApiSessionToRestModel(ae *env.AppEnv, apiSession *model.ApiSession) (*rest_model.APISessionDetail, error) {
 	authQueries := rest_model.AuthQueryList{}
 
-	isMfaEnabled := apiSession.MfaRequired && !apiSession.MfaComplete
-
-	if isMfaEnabled {
+	if apiSession.MfaRequired && !apiSession.MfaComplete {
 		authQueries = append(authQueries, newAuthCheckZitiMfa())
 	}
 
@@ -98,7 +96,8 @@ func MapApiSessionToRestModel(ae *env.AppEnv, apiSession *model.ApiSession) (*re
 		IPAddress:      &apiSession.IPAddress,
 		ConfigTypes:    stringz.SetToSlice(apiSession.ConfigTypes),
 		AuthQueries:    authQueries,
-		IsMfaEnabled:   &isMfaEnabled,
+		IsMfaComplete:  &apiSession.MfaComplete,
+		IsMfaRequired:  &apiSession.MfaRequired,
 		LastActivityAt: lastActivityAt,
 	}
 

--- a/controller/internal/routes/authenticate_router.go
+++ b/controller/internal/routes/authenticate_router.go
@@ -199,22 +199,7 @@ func (ro *AuthRouter) authMfa(ae *env.AppEnv, rc *response.RequestContext, param
 		return
 	}
 
-	postureResponse := &model.PostureResponse{
-		PostureCheckId: model.MfaProviderZiti,
-		TypeId:         "MFA",
-		TimedOut:       false,
-		LastUpdatedAt:  time.Now(),
-	}
-
-	postureSubType := &model.PostureResponseMfa{
-		ApiSessionId: rc.ApiSession.Id,
-		PassedMfa:    true,
-	}
-
-	postureResponse.SubType = postureSubType
-	postureSubType.PostureResponse = postureResponse
-
-	ae.Handlers.PostureResponse.Create(rc.Identity.Id, []*model.PostureResponse{postureResponse})
+	ae.Handlers.PostureResponse.SetMfaPosture(rc.Identity.Id, rc.ApiSession.Id, true)
 
 	rc.RespondWithEmptyOk()
 }

--- a/controller/internal/routes/current_api_session_api_model.go
+++ b/controller/internal/routes/current_api_session_api_model.go
@@ -59,9 +59,8 @@ func (factory *CurrentApiSessionLinkFactoryImpl) Links(entity models.Entity) res
 
 func MapToCurrentApiSessionRestModel(ae *env.AppEnv, apiSession *model.ApiSession, sessionTimeout time.Duration) *rest_model.CurrentAPISessionDetail {
 	authQueries := rest_model.AuthQueryList{}
-	isMfaEnabled := apiSession.MfaRequired && !apiSession.MfaComplete
 
-	if isMfaEnabled {
+	if apiSession.MfaRequired && !apiSession.MfaComplete {
 		authQueries = append(authQueries, newAuthCheckZitiMfa())
 	}
 
@@ -85,7 +84,8 @@ func MapToCurrentApiSessionRestModel(ae *env.AppEnv, apiSession *model.ApiSessio
 			IPAddress:            &apiSession.IPAddress,
 			Token:                &apiSession.Token,
 			AuthQueries:          authQueries,
-			IsMfaEnabled:         &isMfaEnabled,
+			IsMfaComplete:        &apiSession.MfaComplete,
+			IsMfaRequired:        &apiSession.MfaRequired,
 			LastActivityAt:       strfmt.DateTime(lastActivityAt),
 			CachedLastActivityAt: strfmt.DateTime(cachedLastActivityAt),
 		},

--- a/controller/internal/routes/current_identity_router.go
+++ b/controller/internal/routes/current_identity_router.go
@@ -18,12 +18,17 @@ package routes
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge/controller/apierror"
 	"github.com/openziti/edge/controller/env"
 	"github.com/openziti/edge/controller/internal/permissions"
+	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/edge/controller/response"
 	"github.com/openziti/edge/rest_model"
 	"github.com/openziti/edge/rest_server/operations/current_identity"
+	"github.com/openziti/foundation/storage/boltz"
+	"github.com/openziti/foundation/util/errorz"
+	"github.com/pkg/errors"
 	"net/http"
 )
 
@@ -117,7 +122,21 @@ func (r *CurrentIdentityRouter) verifyMfa(ae *env.AppEnv, rc *response.RequestCo
 
 	if ok {
 		mfa.IsVerified = true
-		ae.Handlers.Mfa.Update(mfa)
+		if err := ae.Handlers.Mfa.Update(mfa); err != nil {
+			pfxlog.Logger().Errorf("could not update MFA with new MFA status: %v", err)
+			rc.RespondWithApiError(errorz.NewUnhandled(errors.New("could not update MFA status")))
+			return
+		}
+
+		rc.ApiSession.MfaComplete = true
+		rc.ApiSession.MfaRequired = true
+
+		if err := ae.Handlers.ApiSession.UpdateWithFieldChecker(rc.ApiSession, boltz.MapFieldChecker{persistence.FieldApiSessionMfaComplete: struct{}{}, persistence.FieldApiSessionMfaRequired: struct{}{}}); err != nil {
+			pfxlog.Logger().Errorf("could not update API Session with new MFA status: %v", err)
+		}
+
+		ae.Handlers.PostureResponse.SetMfaPosture(rc.Identity.Id, rc.ApiSession.Id, true)
+
 		rc.RespondWithEmptyOk()
 		return
 
@@ -171,7 +190,7 @@ func (r *CurrentIdentityRouter) detailMfa(ae *env.AppEnv, rc *response.RequestCo
 func (r *CurrentIdentityRouter) removeMfa(ae *env.AppEnv, rc *response.RequestContext, params current_identity.DeleteMfaParams) {
 	code := ""
 
-	if params.MfaValidation != nil && params.MfaValidation.Code != nil{
+	if params.MfaValidation != nil && params.MfaValidation.Code != nil {
 		code = *params.MfaValidation.Code
 	} else if params.MfaValidationCode != nil {
 		code = *params.MfaValidationCode
@@ -270,7 +289,7 @@ func (r *CurrentIdentityRouter) detailMfaRecoveryCodes(ae *env.AppEnv, rc *respo
 
 	code := ""
 
-	if params.MfaValidation != nil && params.MfaValidation.Code != nil{
+	if params.MfaValidation != nil && params.MfaValidation.Code != nil {
 		code = *params.MfaValidation.Code
 	} else if params.MfaValidationCode != nil {
 		code = *params.MfaValidationCode

--- a/controller/internal/routes/current_identity_router.go
+++ b/controller/internal/routes/current_identity_router.go
@@ -203,6 +203,8 @@ func (r *CurrentIdentityRouter) removeMfa(ae *env.AppEnv, rc *response.RequestCo
 		return
 	}
 
+	ae.Handlers.PostureResponse.SetMfaPostureForIdentity(rc.Identity.Id, false)
+
 	rc.RespondWithEmptyOk()
 }
 

--- a/controller/model/api_session_handlers.go
+++ b/controller/model/api_session_handlers.go
@@ -88,6 +88,10 @@ func (handler *ApiSessionHandler) Update(apiSession *ApiSession) error {
 	return handler.updateEntity(apiSession, handler)
 }
 
+func (handler *ApiSessionHandler) UpdateWithFieldChecker(apiSession *ApiSession, fieldChecker boltz.FieldChecker) error {
+	return handler.updateEntity(apiSession, fieldChecker)
+}
+
 func (handler *ApiSessionHandler) MfaCompleted(apiSession *ApiSession) error {
 	apiSession.MfaComplete = true
 	return handler.patchEntity(apiSession, &OrFieldChecker{NewFieldChecker(persistence.FieldApiSessionMfaComplete), handler})

--- a/controller/model/env.go
+++ b/controller/model/env.go
@@ -41,6 +41,7 @@ type Env interface {
 	IsEdgeRouterOnline(id string) bool
 	GetMetricsRegistry() metrics.Registry
 	GetFingerprintGenerator() cert.FingerprintGenerator
+	HandleServiceUpdatedEventForIdentityId(identityId string)
 }
 
 type HostController interface {

--- a/controller/model/posture_response_handlers.go
+++ b/controller/model/posture_response_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"go.etcd.io/bbolt"
 	"runtime/debug"
+	"time"
 )
 
 func NewPostureResponseHandler(env Env) *PostureResponseHandler {
@@ -40,6 +41,25 @@ type PostureResponseHandler struct {
 
 func (handler *PostureResponseHandler) Create(identityId string, postureResponses []*PostureResponse) {
 	handler.postureCache.Add(identityId, postureResponses)
+}
+
+func (handler *PostureResponseHandler) SetMfaPosture(identityId string, apiSessionId string, isPassed bool) {
+	postureResponse := &PostureResponse{
+		PostureCheckId: MfaProviderZiti,
+		TypeId:         "MFA",
+		TimedOut:       false,
+		LastUpdatedAt:  time.Now(),
+	}
+
+	postureSubType := &PostureResponseMfa{
+		ApiSessionId: apiSessionId,
+		PassedMfa:    isPassed,
+	}
+
+	postureResponse.SubType = postureSubType
+	postureSubType.PostureResponse = postureResponse
+
+	handler.Create(identityId, []*PostureResponse{postureResponse})
 }
 
 func (handler *PostureResponseHandler) AddPostureDataListener(cb func(identityId string)) {

--- a/controller/model/posture_response_handlers.go
+++ b/controller/model/posture_response_handlers.go
@@ -46,7 +46,7 @@ func (handler *PostureResponseHandler) Create(identityId string, postureResponse
 func (handler *PostureResponseHandler) SetMfaPosture(identityId string, apiSessionId string, isPassed bool) {
 	postureResponse := &PostureResponse{
 		PostureCheckId: MfaProviderZiti,
-		TypeId:         "MFA",
+		TypeId:         PostureCheckTypeMFA,
 		TimedOut:       false,
 		LastUpdatedAt:  time.Now(),
 	}
@@ -62,7 +62,33 @@ func (handler *PostureResponseHandler) SetMfaPosture(identityId string, apiSessi
 	handler.Create(identityId, []*PostureResponse{postureResponse})
 }
 
-func (handler *PostureResponseHandler) AddPostureDataListener(cb func(identityId string)) {
+func (handler *PostureResponseHandler) SetMfaPostureForIdentity(identityId string, isPassed bool) {
+	postureResponse := &PostureResponse{
+		PostureCheckId: MfaProviderZiti,
+		TypeId:         PostureCheckTypeMFA,
+		TimedOut:       false,
+		LastUpdatedAt:  time.Now(),
+	}
+
+	pd := handler.postureCache.PostureData(identityId)
+
+	if pd != nil {
+		for apiSessionId, _ := range pd.ApiSessions {
+			postureSubType := &PostureResponseMfa{
+				ApiSessionId: apiSessionId,
+				PassedMfa:    isPassed,
+			}
+
+			postureResponse.SubType = postureSubType
+			postureSubType.PostureResponse = postureResponse
+
+			handler.Create(identityId, []*PostureResponse{postureResponse})
+		}
+	}
+}
+
+
+func (handler *PostureResponseHandler) AddPostureDataListener(cb func(env Env, identityId string)) {
 	handler.postureCache.AddListener(EventIdentityPostureDataAltered, func(i ...interface{}) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -71,15 +97,19 @@ func (handler *PostureResponseHandler) AddPostureDataListener(cb func(identityId
 			}
 		}()
 		if identityId, ok := i[0].(string); ok {
-			cb(identityId)
+			cb(handler.env, identityId)
 		}
 	})
 }
 
 // Kills active sessions that do not have passing posture checks. Run when posture data is updated
 // via posture response or posture data timeout.
-func (handler *PostureResponseHandler) postureDataUpdated(identityId string) {
+func (handler *PostureResponseHandler) postureDataUpdated(env Env, identityId string) {
 	var sessionIdsToDelete []string
+
+	//todo: Be smarter about this? Store a cache of service-> result on postureDataCach detect changes?
+	// Only an issue when timeouts are being used - which aren't right now.
+	env.HandleServiceUpdatedEventForIdentityId(identityId)
 
 	err := handler.env.GetDbProvider().GetDb().View(func(tx *bbolt.Tx) error {
 		apiSessionIds, _, err := handler.env.GetStores().ApiSession.QueryIds(tx, fmt.Sprintf(`identity = "%v"`, identityId))

--- a/controller/model/posture_response_model.go
+++ b/controller/model/posture_response_model.go
@@ -60,6 +60,7 @@ func (pc *PostureCache) Add(identityId string, postureResponses []*PostureRespon
 
 		return postureData
 	})
+
 	pc.Emit(EventIdentityPostureDataAltered, identityId)
 }
 

--- a/controller/model/posture_response_model_mfa.go
+++ b/controller/model/posture_response_model_mfa.go
@@ -34,13 +34,10 @@ func (pr *PostureResponseMfa) Apply(postureData *PostureData) {
 		postureData.ApiSessions = map[string]*ApiSessionPostureData{}
 	}
 
-	apiSessionPostureData := postureData.ApiSessions[pr.ApiSessionId]
-
-	if apiSessionPostureData == nil {
-		apiSessionPostureData = &ApiSessionPostureData{}
-		postureData.ApiSessions[pr.ApiSessionId] = apiSessionPostureData
+	if  postureData.ApiSessions[pr.ApiSessionId] == nil {
+		postureData.ApiSessions[pr.ApiSessionId] = &ApiSessionPostureData{}
 	}
 
-	apiSessionPostureData.Mfa = pr
-	apiSessionPostureData.Mfa.LastUpdatedAt = time.Now().UTC()
+	postureData.ApiSessions[pr.ApiSessionId].Mfa = pr
+	postureData.ApiSessions[pr.ApiSessionId].Mfa.LastUpdatedAt = time.Now().UTC()
 }

--- a/controller/model/testing.go
+++ b/controller/model/testing.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 )
 
+var _ Env = &TestContext{}
 
 type TestContext struct {
 	*persistence.TestContext
@@ -34,6 +35,8 @@ type TestContext struct {
 	config          *config.Config
 	metricsRegistry metrics.Registry
 }
+
+func (ctx *TestContext) HandleServiceUpdatedEventForIdentityId(identityId string) {}
 
 func (ctx *TestContext) Generate(string, string, jwt2.MapClaims) (string, error) {
 	return "I'm a very legitimate claim", nil

--- a/rest_model/api_session_detail.go
+++ b/rest_model/api_session_detail.go
@@ -66,9 +66,13 @@ type APISessionDetail struct {
 	// Required: true
 	IPAddress *string `json:"ipAddress"`
 
-	// is mfa enabled
+	// is mfa complete
 	// Required: true
-	IsMfaEnabled *bool `json:"isMfaEnabled"`
+	IsMfaComplete *bool `json:"isMfaComplete"`
+
+	// is mfa required
+	// Required: true
+	IsMfaRequired *bool `json:"isMfaRequired"`
 
 	// last activity at
 	// Format: date-time
@@ -102,7 +106,9 @@ func (m *APISessionDetail) UnmarshalJSON(raw []byte) error {
 
 		IPAddress *string `json:"ipAddress"`
 
-		IsMfaEnabled *bool `json:"isMfaEnabled"`
+		IsMfaComplete *bool `json:"isMfaComplete"`
+
+		IsMfaRequired *bool `json:"isMfaRequired"`
 
 		LastActivityAt strfmt.DateTime `json:"lastActivityAt,omitempty"`
 
@@ -124,7 +130,9 @@ func (m *APISessionDetail) UnmarshalJSON(raw []byte) error {
 
 	m.IPAddress = dataAO1.IPAddress
 
-	m.IsMfaEnabled = dataAO1.IsMfaEnabled
+	m.IsMfaComplete = dataAO1.IsMfaComplete
+
+	m.IsMfaRequired = dataAO1.IsMfaRequired
 
 	m.LastActivityAt = dataAO1.LastActivityAt
 
@@ -155,7 +163,9 @@ func (m APISessionDetail) MarshalJSON() ([]byte, error) {
 
 		IPAddress *string `json:"ipAddress"`
 
-		IsMfaEnabled *bool `json:"isMfaEnabled"`
+		IsMfaComplete *bool `json:"isMfaComplete"`
+
+		IsMfaRequired *bool `json:"isMfaRequired"`
 
 		LastActivityAt strfmt.DateTime `json:"lastActivityAt,omitempty"`
 
@@ -174,7 +184,9 @@ func (m APISessionDetail) MarshalJSON() ([]byte, error) {
 
 	dataAO1.IPAddress = m.IPAddress
 
-	dataAO1.IsMfaEnabled = m.IsMfaEnabled
+	dataAO1.IsMfaComplete = m.IsMfaComplete
+
+	dataAO1.IsMfaRequired = m.IsMfaRequired
 
 	dataAO1.LastActivityAt = m.LastActivityAt
 
@@ -221,7 +233,11 @@ func (m *APISessionDetail) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateIsMfaEnabled(formats); err != nil {
+	if err := m.validateIsMfaComplete(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIsMfaRequired(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -313,9 +329,18 @@ func (m *APISessionDetail) validateIPAddress(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *APISessionDetail) validateIsMfaEnabled(formats strfmt.Registry) error {
+func (m *APISessionDetail) validateIsMfaComplete(formats strfmt.Registry) error {
 
-	if err := validate.Required("isMfaEnabled", "body", m.IsMfaEnabled); err != nil {
+	if err := validate.Required("isMfaComplete", "body", m.IsMfaComplete); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *APISessionDetail) validateIsMfaRequired(formats strfmt.Registry) error {
+
+	if err := validate.Required("isMfaRequired", "body", m.IsMfaRequired); err != nil {
 		return err
 	}
 

--- a/rest_server/embedded_spec.go
+++ b/rest_server/embedded_spec.go
@@ -6294,7 +6294,8 @@ func init() {
             "ipAddress",
             "authQueries",
             "cachedUpdatedAt",
-            "isMfaEnabled"
+            "isMfaRequired",
+            "isMfaComplete"
           ],
           "properties": {
             "authQueries": {
@@ -6319,7 +6320,10 @@ func init() {
             "ipAddress": {
               "type": "string"
             },
-            "isMfaEnabled": {
+            "isMfaComplete": {
+              "type": "boolean"
+            },
+            "isMfaRequired": {
               "type": "boolean"
             },
             "lastActivityAt": {
@@ -26496,7 +26500,8 @@ func init() {
             "ipAddress",
             "authQueries",
             "cachedUpdatedAt",
-            "isMfaEnabled"
+            "isMfaRequired",
+            "isMfaComplete"
           ],
           "properties": {
             "authQueries": {
@@ -26521,7 +26526,10 @@ func init() {
             "ipAddress": {
               "type": "string"
             },
-            "isMfaEnabled": {
+            "isMfaComplete": {
+              "type": "boolean"
+            },
+            "isMfaRequired": {
               "type": "boolean"
             },
             "lastActivityAt": {

--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -4481,7 +4481,8 @@ definitions:
           - ipAddress
           - authQueries
           - cachedUpdatedAt
-          - isMfaEnabled
+          - isMfaRequired
+          - isMfaComplete
         properties:
           token:
             type: string
@@ -4497,7 +4498,9 @@ definitions:
               type: string
           authQueries:
             $ref: '#/definitions/authQueryList'
-          isMfaEnabled:
+          isMfaRequired:
+            type: boolean
+          isMfaComplete:
             type: boolean
           lastActivityAt:
             type: string

--- a/tests/posture_check_mfa_test.go
+++ b/tests/posture_check_mfa_test.go
@@ -151,12 +151,12 @@ func Test_MFA_PostureChecks(t *testing.T) {
 				ctx.Req.NoError(err)
 				standardJsonResponseTests(resp, http.StatusOK, t)
 
-				t.Run(" does not allow service session creation", func(t *testing.T) {
+				t.Run("allows service session creation", func(t *testing.T) {
 					ctx.testContextChanged(t)
 					resp, err := enrolledIdentitySession.createNewSession(service.Id)
 					ctx.Req.NoError(err)
 
-					ctx.Req.Equal(http.StatusConflict, resp.StatusCode())
+					ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
 				})
 			})
 

--- a/tests/posture_check_test.go
+++ b/tests/posture_check_test.go
@@ -298,6 +298,7 @@ func Test_PostureChecks(t *testing.T) {
 			ctx.Req.True(enrolledIdentitySession.isServiceVisibleToUser(service.Id))
 		})
 
+
 		t.Run("service has the posture check in its queries", func(t *testing.T) {
 			ctx.testContextChanged(t)
 			code, body := enrolledIdentitySession.query("/services/" + service.Id)
@@ -332,8 +333,18 @@ func Test_PostureChecks(t *testing.T) {
 		})
 
 		t.Run("providing valid posture data", func(t *testing.T) {
+
 			ctx.testContextChanged(t)
+
+			beforeLastChangedAt := enrolledIdentitySession.getServiceUpdateTime()
+
 			enrolledIdentitySession.requireNewPostureResponseDomain(postureCheck.id, domain)
+
+			afterLastChangedAt := enrolledIdentitySession.getServiceUpdateTime()
+
+			t.Run("service update changed with posture data change", func(t *testing.T) {
+				ctx.Req.True(afterLastChangedAt.After(beforeLastChangedAt), "expected last changed at to have been updated after posture submissions")
+			})
 
 			t.Run("allows posture checks to pass", func(t *testing.T) {
 				ctx.testContextChanged(t)


### PR DESCRIPTION
- update api session session state on mfa enroll, remove
- update posture data state on mfa enroll
- centralize setting mfa posture data
- pass isMfaRequired and isMfaComplete in apiSession/currentApiSession
- on posture data  change trigger service update