### PR TITLE
Empty Posture Fix & Minor Fixes

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -295,7 +295,7 @@ func NewAppEnv(c *edgeConfig.Config) *AppEnv {
 		EnrollRegistry:     &model.EnrollmentRegistryImpl{},
 		Api:                api,
 		IdentityRefreshMap: cmap.New(),
-		StartupTime:        time.Now(),
+		StartupTime:        time.Now().UTC(),
 	}
 
 	api.APIAuthorizer = authorizer{}
@@ -477,5 +477,5 @@ func (ae *AppEnv) HandleServiceEvent(event *persistence.ServiceEvent) {
 }
 
 func (ae *AppEnv) HandleServiceUpdatedEventForIdentityId(identityId string) {
-	ae.IdentityRefreshMap.Set(identityId, time.Now())
+	ae.IdentityRefreshMap.Set(identityId, time.Now().UTC())
 }

--- a/controller/model/posture_response_handlers.go
+++ b/controller/model/posture_response_handlers.go
@@ -48,7 +48,7 @@ func (handler *PostureResponseHandler) SetMfaPosture(identityId string, apiSessi
 		PostureCheckId: MfaProviderZiti,
 		TypeId:         PostureCheckTypeMFA,
 		TimedOut:       false,
-		LastUpdatedAt:  time.Now(),
+		LastUpdatedAt:  time.Now().UTC(),
 	}
 
 	postureSubType := &PostureResponseMfa{
@@ -67,7 +67,7 @@ func (handler *PostureResponseHandler) SetMfaPostureForIdentity(identityId strin
 		PostureCheckId: MfaProviderZiti,
 		TypeId:         PostureCheckTypeMFA,
 		TimedOut:       false,
-		LastUpdatedAt:  time.Now(),
+		LastUpdatedAt:  time.Now().UTC(),
 	}
 
 	pd := handler.postureCache.PostureData(identityId)

--- a/controller/model/service_handlers.go
+++ b/controller/model/service_handlers.go
@@ -302,6 +302,9 @@ func (handler *EdgeServiceHandler) GetPostureChecks(identityId, serviceId string
 			policyId := policyCursor.Current()
 			policyCursor.Next()
 
+			//required to provide an entry for policies w/ no checks
+			policyIdToChecks[string(policyId)] = nil
+
 			cursor := postureCheckLinks.IterateLinks(tx, policyId)
 			for cursor.IsValid() {
 				checkId := string(cursor.Current())

--- a/controller/persistence/policy_common.go
+++ b/controller/persistence/policy_common.go
@@ -19,13 +19,14 @@ type serviceEventHandler struct {
 
 func (self *serviceEventHandler) addServiceUpdatedEvent(store *baseStore, tx *bbolt.Tx, serviceId []byte) {
 	cursor := store.stores.edgeService.bindIdentitiesCollection.IterateLinks(tx, serviceId)
-	for cursor.IsValid() {
+
+	for cursor != nil && cursor.IsValid() {
 		self.addServiceEvent(tx, cursor.Current(), serviceId, ServiceUpdated)
 		cursor.Next()
 	}
 
 	cursor = store.stores.edgeService.dialIdentitiesCollection.IterateLinks(tx, serviceId)
-	for cursor.IsValid() {
+	for cursor != nil && cursor.IsValid() {
 		self.addServiceEvent(tx, cursor.Current(), serviceId, ServiceUpdated)
 		cursor.Next()
 	}

--- a/tests/posture_check_test.go
+++ b/tests/posture_check_test.go
@@ -438,4 +438,86 @@ func Test_PostureChecks(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("can create a domain posture check associated to a service policy and have service policy with no posture checks", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		identityRole := eid.New()
+		serviceRole := eid.New()
+		postureCheckRole := eid.New()
+
+		_, enrolledIdentityAuthenticator := ctx.AdminSession.requireCreateIdentityOttEnrollment(eid.New(), false, identityRole)
+		enrolledIdentitySession, err := enrolledIdentityAuthenticator.Authenticate(ctx)
+
+		ctx.Req.NoError(err)
+
+		service := ctx.AdminSession.requireNewService(s(serviceRole), nil)
+
+		domain := "domain1"
+		_ = ctx.AdminSession.requireNewPostureCheckDomain(s(domain), s(postureCheckRole))
+
+		ctx.AdminSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+identityRole), s("#"+postureCheckRole))
+		ctx.AdminSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+identityRole), nil)
+
+		ctx.AdminSession.requireNewEdgeRouterPolicy(s("#all"), s("#"+identityRole))
+
+		ctx.AdminSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#"+serviceRole))
+
+		ctx.Req.NoError(err)
+
+		t.Run("identity can see service via policies", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(enrolledIdentitySession.isServiceVisibleToUser(service.Id))
+		})
+
+
+		t.Run("can create session with failing queries via one service policy by having another service policy with no checks", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			resp, err := enrolledIdentitySession.createNewSession(service.Id)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+		})
+	})
+
+	t.Run("can create an mfa posture check associated to a service policy", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		identityRole := eid.New()
+		serviceRole := eid.New()
+		postureCheckRole := eid.New()
+
+		_, enrolledIdentityAuthenticator := ctx.AdminSession.requireCreateIdentityOttEnrollment(eid.New(), false, identityRole)
+		enrolledIdentitySession, err := enrolledIdentityAuthenticator.Authenticate(ctx)
+
+		ctx.Req.NoError(err)
+
+		service := ctx.AdminSession.requireNewService(s(serviceRole), nil)
+
+		_ = ctx.AdminSession.requireNewPostureCheckMFA(s(postureCheckRole))
+
+		ctx.AdminSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+identityRole), s("#"+postureCheckRole))
+
+		ctx.AdminSession.requireNewEdgeRouterPolicy(s("#all"), s("#"+identityRole))
+
+		ctx.AdminSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#"+serviceRole))
+
+		ctx.Req.NoError(err)
+
+		t.Run("identity can see service via policies", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(enrolledIdentitySession.isServiceVisibleToUser(service.Id))
+		})
+
+
+		t.Run("can create session with failing queries via one service policy by having another service policy with no checks", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			resp, err := enrolledIdentitySession.createNewSession(service.Id)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+		})
+	})
+
+
 }

--- a/tests/posture_check_test.go
+++ b/tests/posture_check_test.go
@@ -497,6 +497,7 @@ func Test_PostureChecks(t *testing.T) {
 		_ = ctx.AdminSession.requireNewPostureCheckMFA(s(postureCheckRole))
 
 		ctx.AdminSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+identityRole), s("#"+postureCheckRole))
+		ctx.AdminSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+identityRole), nil)
 
 		ctx.AdminSession.requireNewEdgeRouterPolicy(s("#all"), s("#"+identityRole))
 


### PR DESCRIPTION
- fix policies w/ no checks not granting access.
- fix non-utc times being used in places
- fix entities not referenced by any attributes causing panics on nil cursor
