### PR TITLE
Fix issues with host.v1 config type schema

### DIFF
--- a/controller/persistence/migration_initialize.go
+++ b/controller/persistence/migration_initialize.go
@@ -316,6 +316,7 @@ var tunnelDefinitions = map[string]interface{}{
 			"low":  map[string]interface{}{"$ref": "#/definitions/portNumber"},
 			"high": map[string]interface{}{"$ref": "#/definitions/portNumber"},
 		},
+		"required": []interface{}{"low", "high"},
 	},
 	"protocolName": map[string]interface{}{
 		"type": "string",

--- a/controller/persistence/migrations.go
+++ b/controller/persistence/migrations.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	CurrentDbVersion = 21
+	CurrentDbVersion = 22
 	FieldVersion     = "version"
 )
 
@@ -87,6 +87,11 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 
 	if step.CurrentVersion < 21 {
 		step.SetError(m.stores.ConfigType.Update(step.Ctx, interceptV1ConfigType, nil))
+		step.SetError(m.stores.ConfigType.Update(step.Ctx, hostV1ConfigType, nil))
+		step.SetError(m.stores.ConfigType.Update(step.Ctx, hostV2ConfigType, nil))
+	}
+
+	if step.CurrentVersion < 22 {
 		step.SetError(m.stores.ConfigType.Update(step.Ctx, hostV1ConfigType, nil))
 		step.SetError(m.stores.ConfigType.Update(step.Ctx, hostV2ConfigType, nil))
 	}

--- a/tunnel/entities/host.v1.json
+++ b/tunnel/entities/host.v1.json
@@ -71,7 +71,11 @@
           "high": {
             "$ref": "#/$defs/portNumber"
           }
-        }
+        },
+        "required": [
+          "low",
+          "high"
+        ]
       },
       "protocolName": {
         "type": "string",
@@ -173,7 +177,7 @@
           },
           {
             "items": {
-              "$ref": "#/$defs/dialAddress"
+              "$ref": "#/$defs/listenAddress"
             }
           }
         ]

--- a/tunnel/entities/host.v1.json
+++ b/tunnel/entities/host.v1.json
@@ -136,7 +136,7 @@
       {
         "if": {
           "properties": {
-            "forwardProtocol": {
+            "forwardPort": {
               "const": true
             }
           },

--- a/tunnel/entities/host.v2.json
+++ b/tunnel/entities/host.v2.json
@@ -258,7 +258,7 @@
         {
           "if": {
             "properties": {
-              "forwardProtocol": {
+              "forwardPort": {
                 "const": true
               }
             },

--- a/tunnel/entities/host.v2.json
+++ b/tunnel/entities/host.v2.json
@@ -156,7 +156,11 @@
         "high": {
           "$ref": "#/definitions/portNumber"
         }
-      }
+      },
+      "required": [
+        "low",
+        "high"
+      ]
     },
     "protocolName": {
       "type": "string",
@@ -295,7 +299,7 @@
             },
             {
               "items": {
-                "$ref": "#/definitions/dialAddress"
+                "$ref": "#/definitions/listenAddress"
               }
             }
           ]


### PR DESCRIPTION
- require "low" and "high" properties in "portRange" objects
- copy/paste zeal in reference json schemas