### PR TITLE
fixes deadlocks when a router disconnects mid sync or update

### DIFF
--- a/controller/sync_strats/rtx.go
+++ b/controller/sync_strats/rtx.go
@@ -72,9 +72,7 @@ func (rtx *RouterSender) Start() {
 
 func (rtx *RouterSender) Stop() {
 	if rtx.stopping.CompareAndSwap(false, true) {
-		go func() {
-			rtx.closeNotify <- struct{}{}
-		}()
+		close(rtx.closeNotify)
 	}
 }
 

--- a/controller/sync_strats/rtx.go
+++ b/controller/sync_strats/rtx.go
@@ -32,13 +32,13 @@ import (
 // to asynchronously buffer and send messages to an Edge Router via Start() then Send()
 type RouterSender struct {
 	env.RouterState
-	Id         string
-	EdgeRouter *model.EdgeRouter
-	Router     *network.Router
-	send       chan *channel2.Message
-	stop       chan interface{}
-	running    concurrenz.AtomicBoolean
-	stopping   concurrenz.AtomicBoolean
+	Id          string
+	EdgeRouter  *model.EdgeRouter
+	Router      *network.Router
+	send        chan *channel2.Message
+	closeNotify chan struct{}
+	running     concurrenz.AtomicBoolean
+	stopping    concurrenz.AtomicBoolean
 
 	sync.Mutex
 }
@@ -49,7 +49,7 @@ func newRouterSender(edgeRouter *model.EdgeRouter, router *network.Router, sendB
 		EdgeRouter:  edgeRouter,
 		Router:      router,
 		send:        make(chan *channel2.Message, sendBufferSize),
-		stop:        make(chan interface{}, 0),
+		closeNotify: make(chan struct{}, 0),
 		running:     concurrenz.AtomicBoolean(0),
 		stopping:    concurrenz.AtomicBoolean(0),
 		RouterState: env.NewLockingRouterStatus(),
@@ -73,7 +73,7 @@ func (rtx *RouterSender) Start() {
 func (rtx *RouterSender) Stop() {
 	if rtx.stopping.CompareAndSwap(false, true) {
 		go func() {
-			rtx.stop <- struct{}{}
+			rtx.closeNotify <- struct{}{}
 		}()
 	}
 }
@@ -81,7 +81,7 @@ func (rtx *RouterSender) Stop() {
 func (rtx *RouterSender) run() {
 	for {
 		select {
-		case <-rtx.stop:
+		case <-rtx.closeNotify:
 			rtx.running.Set(false)
 			rtx.stopping.Set(false)
 			return
@@ -103,7 +103,26 @@ func (rtx *RouterSender) logger() *logrus.Entry {
 }
 
 func (rtx *RouterSender) Send(msg *channel2.Message) {
-	rtx.send <- msg
+	if rtx.stopping.Get() || !rtx.running.Get() {
+		pfxlog.Logger().Errorf("cannot send to router [%s], rtx'er is stopped", rtx.Router.Id)
+		return
+	}
+
+	if rtx.Router.Control.IsClosed() {
+		pfxlog.Logger().Errorf("cannot send to router [%s], rtx's channel is closed", rtx.Router.Id)
+		rtx.Stop()
+		return
+	}
+
+	select {
+	case rtx.send <- msg:
+	case <-rtx.closeNotify:
+	}
+
+}
+
+func (rtx *RouterSender) IsConnected() bool {
+	return !rtx.Router.Control.IsClosed()
 }
 
 // Map used make working with internal RouterSender easier as sync.Map accepts and returns interface{}
@@ -137,21 +156,23 @@ func (m *routerTxMap) Remove(id string) {
 	}
 }
 
-func (m *routerTxMap) Range(f func(entries *RouterSender) bool) {
+// Range creates a snapshot of the rtx's to loop over and will execute callback
+// with each rtx.
+func (m *routerTxMap) Range(callback func(entries *RouterSender) bool) {
+	var rtxs []*RouterSender
+
 	m.internalMap.Range(func(edgeRouterId, value interface{}) bool {
 		if rtx, ok := value.(*RouterSender); ok {
-			return f(rtx)
+			rtxs = append(rtxs, rtx)
+		} else {
+			pfxlog.Logger().Errorf("could not convert edge router entry got %t: %v", value, value)
 		}
-		pfxlog.Logger().Panic("could not convert edge router entry")
+
 		return false
 	})
-}
 
-// Helper to generate channel2.ReceiveHandler instances from a contentType and function
-func newReceiveHandlerFunc(contentType int32, handler func(m *channel2.Message, ch channel2.Channel)) channel2.ReceiveHandler {
-	return receiveHandlerFunc{
-		contentType: contentType,
-		handler:     handler,
+	for _, rtx := range rtxs {
+		callback(rtx)
 	}
 }
 


### PR DESCRIPTION
- range() of rtx'ers no longer locks, snapshots then loops
- rtx.Send() now checks for stopped/disconnected
- rtx.Send() now respects closeNotify