### PR TITLE
Lower fabric dep to isolate changes for release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/miekg/dns v1.1.42
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/netfoundry/secretstream v0.1.2
-	github.com/openziti/fabric v0.16.65
+	github.com/openziti/fabric v0.16.64
 	github.com/openziti/foundation v0.15.53
 	github.com/openziti/sdk-golang v0.15.50
 	github.com/orcaman/concurrent-map v0.0.0-20210106121528-16402b402231

--- a/go.sum
+++ b/go.sum
@@ -487,6 +487,8 @@ github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/openziti/bbolt v1.3.6-0.20210317142109-547da822475e h1:ST9+54UtCr96S5+Wa7LQtpGS6/xK7Z+KQXvOAtYgJlA=
 github.com/openziti/bbolt v1.3.6-0.20210317142109-547da822475e/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 github.com/openziti/dilithium v0.3.3/go.mod h1:vsCjI2AU/hon9e+dLhUFbCNGesJDj2ASgkySOcpmvjo=
+github.com/openziti/fabric v0.16.64 h1:arJPbmAzTJ0nF3jCyYU6AH4J94QXoz0uHYMErKssMgc=
+github.com/openziti/fabric v0.16.64/go.mod h1:WX5RRBP4jEMaF9R7yHK/q2C+qFuzgN7k/Y97tfO5XQE=
 github.com/openziti/fabric v0.16.65 h1:cAt+wvp7a1gUUCbtHFVdw827z+alW7JJER33mKWJbUk=
 github.com/openziti/fabric v0.16.65/go.mod h1:WX5RRBP4jEMaF9R7yHK/q2C+qFuzgN7k/Y97tfO5XQE=
 github.com/openziti/foundation v0.15.52/go.mod h1:NnSBTp9ZkcYsv6nYxZR0/NzoHfkIo6tjpBHDvBsPFqw=


### PR DESCRIPTION
Ziti-CI snuck in and updated the dep. Reverting to keep changes isolated for 0.20.6's release.