### PR TITLE
fixes issues with process multi's patch

### DIFF
--- a/controller/internal/routes/posture_check_api_model.go
+++ b/controller/internal/routes/posture_check_api_model.go
@@ -364,6 +364,14 @@ func MapPostureCheckToRestModel(i *model.PostureCheck) (rest_model.PostureCheckD
 				SignerFingerprints: process.SignerFingerprints,
 			}
 
+			if newProc.Hashes == nil {
+				newProc.Hashes = []string{}
+			}
+
+			if newProc.SignerFingerprints == nil {
+				newProc.SignerFingerprints = []string{}
+			}
+
 			detail.Processes = append(detail.Processes, newProc)
 		}
 

--- a/controller/internal/routes/posture_check_router.go
+++ b/controller/internal/routes/posture_check_router.go
@@ -155,6 +155,13 @@ func (r *PostureCheckRouter) Patch(ae *env.AppEnv, rc *response.RequestContext, 
 			fields.AddField(persistence.FieldPostureCheckProcessFingerprint)
 		}
 
+		if fields.IsUpdated("processes") {
+			fields.AddField(persistence.FieldPostureCheckProcessMultiPath)
+			fields.AddField(persistence.FieldPostureCheckProcessMultiOsType)
+			fields.AddField(persistence.FieldPostureCheckProcessMultiSignerFingerprints)
+			fields.AddField(persistence.FieldPostureCheckProcessMultiHashes)
+		}
+
 		return ae.Handlers.PostureCheck.Patch(check, fields.FilterMaps("tags"))
 	})
 }

--- a/controller/model/posture_check_handlers.go
+++ b/controller/model/posture_check_handlers.go
@@ -72,7 +72,13 @@ func (handler *PostureCheckHandler) IsUpdated(field string) bool {
 		strings.EqualFold(field, persistence.FieldPostureCheckProcessFingerprint) ||
 		strings.EqualFold(field, persistence.FieldPostureCheckProcessOs) ||
 		strings.EqualFold(field, persistence.FieldPostureCheckProcessPath) ||
-		strings.EqualFold(field, persistence.FieldPostureCheckProcessHashes)
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessHashes) ||
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessMultiOsType) ||
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessMultiHashes) ||
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessMultiPath) ||
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessMultiSignerFingerprints) ||
+		strings.EqualFold(field, persistence.FieldPostureCheckProcessMultiProcesses) ||
+		strings.EqualFold(field, persistence.FieldSemantic)
 }
 
 func (handler *PostureCheckHandler) Update(ca *PostureCheck) error {

--- a/rest_management_api_server/embedded_spec.go
+++ b/rest_management_api_server/embedded_spec.go
@@ -17045,6 +17045,9 @@ func init() {
     },
     "postureCheckPatch": {
       "type": "object",
+      "required": [
+        "typeId"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -17054,6 +17057,9 @@ func init() {
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        },
+        "typeId": {
+          "$ref": "#/definitions/postureCheckType"
         }
       },
       "discriminator": "typeId"
@@ -35719,6 +35725,9 @@ func init() {
     },
     "postureCheckPatch": {
       "type": "object",
+      "required": [
+        "typeId"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -35728,6 +35737,9 @@ func init() {
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        },
+        "typeId": {
+          "$ref": "#/definitions/postureCheckType"
         }
       },
       "discriminator": "typeId"

--- a/rest_model/posture_check_domain_patch.go
+++ b/rest_model/posture_check_domain_patch.go
@@ -85,6 +85,15 @@ func (m *PostureCheckDomainPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckDomainPatch) TypeID() PostureCheckType {
+	return "DOMAIN"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckDomainPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckDomainPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -109,6 +118,8 @@ func (m *PostureCheckDomainPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -125,6 +136,11 @@ func (m *PostureCheckDomainPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	result.Domains = data.Domains
 
@@ -155,6 +171,8 @@ func (m PostureCheckDomainPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -162,6 +180,8 @@ func (m PostureCheckDomainPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -276,6 +296,18 @@ func (m *PostureCheckDomainPatch) contextValidateTags(ctx context.Context, forma
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckDomainPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_mac_address_patch.go
+++ b/rest_model/posture_check_mac_address_patch.go
@@ -85,6 +85,15 @@ func (m *PostureCheckMacAddressPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckMacAddressPatch) TypeID() PostureCheckType {
+	return "MAC"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckMacAddressPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckMacAddressPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -109,6 +118,8 @@ func (m *PostureCheckMacAddressPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -125,6 +136,11 @@ func (m *PostureCheckMacAddressPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	result.MacAddresses = data.MacAddresses
 
@@ -155,6 +171,8 @@ func (m PostureCheckMacAddressPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -162,6 +180,8 @@ func (m PostureCheckMacAddressPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -276,6 +296,18 @@ func (m *PostureCheckMacAddressPatch) contextValidateTags(ctx context.Context, f
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckMacAddressPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_mfa_patch.go
+++ b/rest_model/posture_check_mfa_patch.go
@@ -80,6 +80,15 @@ func (m *PostureCheckMfaPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckMfaPatch) TypeID() PostureCheckType {
+	return "MFA"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckMfaPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckMfaPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -100,6 +109,8 @@ func (m *PostureCheckMfaPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -116,6 +127,11 @@ func (m *PostureCheckMfaPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	*m = result
 
@@ -137,6 +153,8 @@ func (m PostureCheckMfaPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -144,6 +162,8 @@ func (m PostureCheckMfaPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -239,6 +259,18 @@ func (m *PostureCheckMfaPatch) contextValidateTags(ctx context.Context, formats 
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckMfaPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_operating_system_patch.go
+++ b/rest_model/posture_check_operating_system_patch.go
@@ -86,6 +86,15 @@ func (m *PostureCheckOperatingSystemPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckOperatingSystemPatch) TypeID() PostureCheckType {
+	return "OS"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckOperatingSystemPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckOperatingSystemPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -110,6 +119,8 @@ func (m *PostureCheckOperatingSystemPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -126,6 +137,11 @@ func (m *PostureCheckOperatingSystemPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	result.OperatingSystems = data.OperatingSystems
 
@@ -156,6 +172,8 @@ func (m PostureCheckOperatingSystemPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -163,6 +181,8 @@ func (m PostureCheckOperatingSystemPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -297,6 +317,18 @@ func (m *PostureCheckOperatingSystemPatch) contextValidateTags(ctx context.Conte
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckOperatingSystemPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_patch.go
+++ b/rest_model/posture_check_patch.go
@@ -62,6 +62,11 @@ type PostureCheckPatch interface {
 	Tags() Tags
 	SetTags(Tags)
 
+	// type Id
+	// Required: true
+	TypeID() PostureCheckType
+	SetTypeID(PostureCheckType)
+
 	// AdditionalProperties in base type shoud be handled just like regular properties
 	// At this moment, the base type property is pushed down to the subtype
 }
@@ -72,6 +77,8 @@ type postureCheckPatch struct {
 	roleAttributesField Attributes
 
 	tagsField Tags
+
+	typeIdField PostureCheckType
 }
 
 // Name gets the name of this polymorphic type
@@ -102,6 +109,15 @@ func (m *postureCheckPatch) Tags() Tags {
 // SetTags sets the tags of this polymorphic type
 func (m *postureCheckPatch) SetTags(val Tags) {
 	m.tagsField = val
+}
+
+// TypeID gets the type Id of this polymorphic type
+func (m *postureCheckPatch) TypeID() PostureCheckType {
+	return "postureCheckPatch"
+}
+
+// SetTypeID sets the type Id of this polymorphic type
+func (m *postureCheckPatch) SetTypeID(val PostureCheckType) {
 }
 
 // UnmarshalPostureCheckPatchSlice unmarshals polymorphic slices of PostureCheckPatch
@@ -258,6 +274,10 @@ func (m *postureCheckPatch) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTypeID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -281,6 +301,18 @@ func (m *postureCheckPatch) contextValidateTags(ctx context.Context, formats str
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *postureCheckPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_process_multi_patch.go
+++ b/rest_model/posture_check_process_multi_patch.go
@@ -89,6 +89,15 @@ func (m *PostureCheckProcessMultiPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckProcessMultiPatch) TypeID() PostureCheckType {
+	return "PROCESS_MULTI"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckProcessMultiPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckProcessMultiPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -116,6 +125,8 @@ func (m *PostureCheckProcessMultiPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -132,6 +143,11 @@ func (m *PostureCheckProcessMultiPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	result.Processes = data.Processes
 	result.Semantic = data.Semantic
@@ -168,6 +184,8 @@ func (m PostureCheckProcessMultiPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -175,6 +193,8 @@ func (m PostureCheckProcessMultiPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -333,6 +353,18 @@ func (m *PostureCheckProcessMultiPatch) contextValidateTags(ctx context.Context,
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckProcessMultiPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/rest_model/posture_check_process_patch.go
+++ b/rest_model/posture_check_process_patch.go
@@ -83,6 +83,15 @@ func (m *PostureCheckProcessPatch) SetTags(val Tags) {
 	m.tagsField = val
 }
 
+// TypeID gets the type Id of this subtype
+func (m *PostureCheckProcessPatch) TypeID() PostureCheckType {
+	return "PROCESS"
+}
+
+// SetTypeID sets the type Id of this subtype
+func (m *PostureCheckProcessPatch) SetTypeID(val PostureCheckType) {
+}
+
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *PostureCheckProcessPatch) UnmarshalJSON(raw []byte) error {
 	var data struct {
@@ -106,6 +115,8 @@ func (m *PostureCheckProcessPatch) UnmarshalJSON(raw []byte) error {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}
 	buf = bytes.NewBuffer(raw)
 	dec = json.NewDecoder(buf)
@@ -122,6 +133,11 @@ func (m *PostureCheckProcessPatch) UnmarshalJSON(raw []byte) error {
 	result.roleAttributesField = base.RoleAttributes
 
 	result.tagsField = base.Tags
+
+	if base.TypeID != result.TypeID() {
+		/* Not the type we're looking for. */
+		return errors.New(422, "invalid typeId value: %q", base.TypeID)
+	}
 
 	result.Process = data.Process
 
@@ -151,6 +167,8 @@ func (m PostureCheckProcessPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes Attributes `json:"roleAttributes"`
 
 		Tags Tags `json:"tags"`
+
+		TypeID PostureCheckType `json:"typeId"`
 	}{
 
 		Name: m.Name(),
@@ -158,6 +176,8 @@ func (m PostureCheckProcessPatch) MarshalJSON() ([]byte, error) {
 		RoleAttributes: m.RoleAttributes(),
 
 		Tags: m.Tags(),
+
+		TypeID: m.TypeID(),
 	})
 	if err != nil {
 		return nil, err
@@ -279,6 +299,18 @@ func (m *PostureCheckProcessPatch) contextValidateTags(ctx context.Context, form
 	if err := m.Tags().ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("tags")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PostureCheckProcessPatch) contextValidateTypeID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.TypeID().ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("typeId")
 		}
 		return err
 	}

--- a/specs/management.yml
+++ b/specs/management.yml
@@ -12074,6 +12074,8 @@ definitions:
     x-class: OS
   postureCheckPatch:
     type: object
+    required:
+    - typeId
     properties:
       name:
         type: string
@@ -12081,6 +12083,8 @@ definitions:
         $ref: '#/definitions/attributes'
       tags:
         $ref: '#/definitions/tags'
+      typeId:
+        $ref: '#/definitions/postureCheckType'
     discriminator: typeId
   postureCheckProcessCreate:
     allOf:

--- a/specs/source/management/posture-checks.yml
+++ b/specs/source/management/posture-checks.yml
@@ -239,9 +239,13 @@ definitions:
   postureCheckPatch:
     type: object
     discriminator: typeId
+    required:
+      - typeId
     properties:
       name:
         type: string
+      typeId:
+        $ref: '../shared/posture-checks.yml#/definitions/postureCheckType'
       roleAttributes:
         $ref: '../shared/base-entity.yml#/definitions/attributes'
       tags:


### PR DESCRIPTION
- NULL output for empty arrays will now be empty array "[]"
- patching no longer clears osType
- patching with the same path between two different OS types no longer
  collides resulting in 1 process being saved