### PR TITLE
fixes #641 enables ?limit=x&offset=x on list association endpoints

### DIFF
--- a/controller/internal/routes/base_router.go
+++ b/controller/internal/routes/base_router.go
@@ -514,10 +514,11 @@ func ListAssociations(rc *response.RequestContext, listF listAssocF) {
 		rc.RespondWithError(err)
 		return
 	}
+	
+	queryOptions, err := GetModelQueryOptionsFromRequest(rc.Request)
 
-	filter := rc.Request.URL.Query().Get("filter")
-	queryOptions := &PublicQueryOptions{
-		Predicate: filter,
+	if err != nil {
+		rc.RespondWithError(err)
 	}
 
 	result, err := listF(rc, id, queryOptions)


### PR DESCRIPTION
Endpoints such as /current-identity/edge-routers would internally use a ListAssociations(...) that would not respect the original query parameters of limit/offset. Instead they would only respect the filter parameter.

Per internal conversations, we agreed to maintain both paths.