### PR TITLE
Add entity count events

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -374,7 +374,7 @@ func (ae *AppEnv) InitPersistence() error {
 	}
 
 	ae.Handlers = model.InitHandlers(ae)
-	events.Init(ae.BoltStores.Session)
+	events.Init(ae.GetDbProvider(), ae.BoltStores, ae.GetHostController().GetCloseNotifyChannel())
 
 	persistence.ServiceEvents.AddServiceEventHandler(ae.HandleServiceEvent)
 	ae.BoltStores.Identity.AddListener(boltz.EventDelete, func(i ...interface{}) {

--- a/controller/persistence/stores.go
+++ b/controller/persistence/stores.go
@@ -73,7 +73,7 @@ func (stores *Stores) buildStoreMap() {
 	}
 }
 
-func (stores *Stores) getStoreList() []Store {
+func (stores *Stores) GetStoreList() []Store {
 	var result []Store
 	for _, crudStore := range stores.storeMap {
 		if store, ok := crudStore.(Store); ok {
@@ -219,7 +219,7 @@ func NewBoltStores(dbProvider DbProvider) (*Stores, error) {
 	externalStores.Index.AddIdSymbol("id", ast.NodeTypeString)
 
 	externalStores.buildStoreMap()
-	storeList := externalStores.getStoreList()
+	storeList := externalStores.GetStoreList()
 
 	err := dbProvider.GetDb().Update(func(tx *bbolt.Tx) error {
 		for _, store := range storeList {

--- a/events/entity_counts.go
+++ b/events/entity_counts.go
@@ -1,0 +1,82 @@
+package events
+
+import (
+	"fmt"
+	"github.com/openziti/edge/controller/persistence"
+	"github.com/pkg/errors"
+	"go.etcd.io/bbolt"
+	"reflect"
+	"time"
+)
+
+const EntityCountEventNS = "edge.entityCounts"
+
+type EntityCountEvent struct {
+	Namespace string           `json:"namespace"`
+	Timestamp time.Time        `json:"timestamp"`
+	Counts    map[string]int64 `json:"counts"`
+	Error     string           `json:"error"`
+}
+
+func (event *EntityCountEvent) String() string {
+	return fmt.Sprintf("%v timestamp=%v counts=%+v err=%v",
+		event.Namespace, event.Timestamp, event.Counts, event.Error)
+}
+
+var entityCountEventGenerator func(interval time.Duration, handler EntityCountEventHandler)
+
+func generateEntityCountEvent(dbProvider persistence.DbProvider, stores *persistence.Stores, handler EntityCountEventHandler) {
+	event := &EntityCountEvent{
+		Namespace: EntityCountEventNS,
+		Timestamp: time.Now(),
+		Counts:    map[string]int64{},
+	}
+
+	for _, store := range stores.GetStoreList() {
+		err := dbProvider.GetDb().View(func(tx *bbolt.Tx) error {
+			_, count, err := store.QueryIds(tx, "true limit 1")
+			if err != nil {
+				return err
+			}
+			event.Counts[store.GetEntityType()] = count
+			return nil
+		})
+
+		if err != nil {
+			event.Error = err.Error()
+			break
+		}
+	}
+
+	handler.AcceptEntityCountEvent(event)
+}
+
+type EntityCountEventHandler interface {
+	AcceptEntityCountEvent(event *EntityCountEvent)
+}
+
+func registerEntityCountEventHandler(val interface{}, config map[interface{}]interface{}) error {
+	handler, ok := val.(EntityCountEventHandler)
+
+	if !ok {
+		return errors.Errorf("type %v doesn't implement github.com/openziti/edge/events/EntityCountEventHandler interface.", reflect.TypeOf(val))
+	}
+
+	interval := time.Minute * 5
+
+	if val, ok := config["interval"]; ok {
+		if strVal, ok := val.(string); ok {
+			var err error
+			interval, err = time.ParseDuration(strVal)
+			if err != nil {
+				return errors.Wrapf(err, "invalid duration value for edge.entityCounts interval: '%v'", strVal)
+			}
+		} else {
+			return errors.Errorf("invalid type %v for edge.entityCounts interval configuration", reflect.TypeOf(val))
+		}
+	}
+
+	go entityCountEventGenerator(interval, handler)
+
+	return nil
+}

--- a/events/formatter.go
+++ b/events/formatter.go
@@ -51,13 +51,28 @@ type EdgeJsonFormatter struct {
 	events.JsonFormatter
 }
 
-func (formatter *EdgeJsonFormatter) AcceptEdgeSessionEvent(event *EdgeSessionEvent) {
-	formatter.AcceptLoggingEvent((*JsonEdgeSessionEvent)(event))
+func (formatter *EdgeJsonFormatter) AcceptSessionEvent(event *SessionEvent) {
+	formatter.AcceptLoggingEvent((*JsonSessionEvent)(event))
 }
 
-type JsonEdgeSessionEvent EdgeSessionEvent
+func (formatter *EdgeJsonFormatter) AcceptEntityCountEvent(event *EntityCountEvent) {
+	formatter.AcceptLoggingEvent((*JsonEntityCountEvent)(event))
+}
 
-func (event *JsonEdgeSessionEvent) WriteTo(output io.WriteCloser) error {
+type JsonSessionEvent SessionEvent
+
+func (event *JsonSessionEvent) WriteTo(output io.WriteCloser) error {
+	buf, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	_, err = output.Write(buf)
+	return err
+}
+
+type JsonEntityCountEvent EntityCountEvent
+
+func (event *JsonEntityCountEvent) WriteTo(output io.WriteCloser) error {
 	buf, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -70,13 +85,24 @@ type EdgePlainTextFormatter struct {
 	events.PlainTextFormatter
 }
 
-func (formatter *EdgePlainTextFormatter) AcceptEdgeSessionEvent(event *EdgeSessionEvent) {
-	formatter.AcceptLoggingEvent((*PlainTextEdgeSessionEvent)(event))
+func (formatter *EdgePlainTextFormatter) AcceptSessionEvent(event *SessionEvent) {
+	formatter.AcceptLoggingEvent((*PlainTextSessionEvent)(event))
 }
 
-type PlainTextEdgeSessionEvent EdgeSessionEvent
+func (formatter *EdgePlainTextFormatter) AcceptEntityCountEvent(event *EntityCountEvent) {
+	formatter.AcceptLoggingEvent((*PlainTextEntityCountEvent)(event))
+}
 
-func (event *PlainTextEdgeSessionEvent) WriteTo(output io.WriteCloser) error {
-	_, err := output.Write([]byte((*EdgeSessionEvent)(event).String() + "\n"))
+type PlainTextSessionEvent SessionEvent
+
+func (event *PlainTextSessionEvent) WriteTo(output io.WriteCloser) error {
+	_, err := output.Write([]byte((*SessionEvent)(event).String() + "\n"))
+	return err
+}
+
+type PlainTextEntityCountEvent EntityCountEvent
+
+func (event *PlainTextEntityCountEvent) WriteTo(output io.WriteCloser) error {
+	_, err := output.Write([]byte((*EntityCountEvent)(event).String() + "\n"))
 	return err
 }

--- a/events/registrations.go
+++ b/events/registrations.go
@@ -1,18 +1,41 @@
 package events
 
 import (
+	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/fabric/events"
+	"github.com/openziti/foundation/storage/boltz"
 	"github.com/openziti/foundation/util/cowslice"
+	"time"
 )
 
 func init() {
-	events.RegisterEventType("edge.sessions", registerSessionEventHandler)
+	events.RegisterEventType(SessionEventNS, registerSessionEventHandler)
+	events.RegisterEventType(EntityCountEventNS, registerEntityCountEventHandler)
 }
 
-func AddSessionEventHandler(handler EdgeSessionEventHandler) {
+func AddSessionEventHandler(handler SessionEventHandler) {
 	cowslice.Append(sessionEventHandlerRegistry, handler)
 }
 
-func RemoveSessionEventHandler(handler EdgeSessionEventHandler) {
+func RemoveSessionEventHandler(handler SessionEventHandler) {
 	cowslice.Delete(sessionEventHandlerRegistry, handler)
+}
+
+func Init(dbProvider persistence.DbProvider, stores *persistence.Stores, closeNotify <-chan struct{}) {
+	stores.Session.AddListener(boltz.EventCreate, sessionCreated)
+	stores.Session.AddListener(boltz.EventDelete, sessionDeleted)
+
+	entityCountEventGenerator = func(interval time.Duration, handler EntityCountEventHandler) {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				generateEntityCountEvent(dbProvider, stores, handler)
+			case <-closeNotify:
+				return
+			}
+		}
+	}
 }

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -63,7 +63,7 @@ func (self *eventsCollector) AcceptUsageEvent(event *events.UsageEvent) {
 	}
 }
 
-func (self *eventsCollector) AcceptEdgeSessionEvent(event *events2.EdgeSessionEvent) {
+func (self *eventsCollector) AcceptSessionEvent(event *events2.SessionEvent) {
 	self.acceptEvent(event)
 }
 
@@ -139,14 +139,14 @@ func Test_EventsTest(t *testing.T) {
 	}
 
 	event := ec.PopNextEvent(ctx)
-	edgeSession, ok := event.(*events2.EdgeSessionEvent)
+	edgeSession, ok := event.(*events2.SessionEvent)
 	ctx.Req.True(ok)
 	ctx.Req.Equal("edge.sessions", edgeSession.Namespace)
 	ctx.Req.Equal("created", edgeSession.EventType)
 	ctx.Req.Equal(hostIdentity.Id, edgeSession.IdentityId)
 
 	event = ec.PopNextEvent(ctx)
-	edgeSession, ok = event.(*events2.EdgeSessionEvent)
+	edgeSession, ok = event.(*events2.SessionEvent)
 	ctx.Req.True(ok)
 	ctx.Req.Equal("edge.sessions", edgeSession.Namespace)
 	ctx.Req.Equal("created", edgeSession.EventType)


### PR DESCRIPTION
Output looks like 

```
{
  "namespace": "edge.entityCounts",
  "timestamp": "2021-08-19T13:39:54.056181406-04:00",
  "counts": {
    "apiSessionCertificates": 0,
    "apiSessions": 9,
    "authenticators": 4,
    "cas": 0,
    "configTypes": 5,
    "configs": 2,
    "edgeRouterPolicies": 4,
    "enrollments": 0,
    "eventLogs": 0,
    "geoRegions": 17,
    "identities": 6,
    "identityTypes": 4,
    "mfas": 0,
    "postureCheckTypes": 5,
    "postureChecks": 0,
    "routers": 2,
    "serviceEdgeRouterPolicies": 2,
    "servicePolicies": 5,
    "services": 3,
    "sessions": 0
  },
  "error": ""
}
```