### PR TITLE
adds EventFullyAuthenticated to the API session store

### DIFF
--- a/controller/env/broker.go
+++ b/controller/env/broker.go
@@ -63,7 +63,7 @@ func NewBroker(ae *AppEnv, synchronizer RouterSyncStrategy) *Broker {
 	}
 
 	broker.ae.GetStores().Session.AddListener(boltz.EventDelete, broker.sessionDeleted)
-	broker.ae.GetStores().ApiSession.AddListener(boltz.EventCreate, broker.apiSessionCreated)
+	broker.ae.GetStores().ApiSession.AddListener(persistence.EventFullyAuthenticated, broker.apiSessionFullyAuthenticated)
 	broker.ae.GetStores().ApiSession.AddListener(boltz.EventDelete, broker.apiSessionDeleted)
 	broker.ae.GetStores().ApiSessionCertificate.AddListener(boltz.EventCreate, broker.apiSessionCertificateCreated)
 	broker.ae.GetStores().ApiSessionCertificate.AddListener(boltz.EventDelete, broker.apiSessionCertificateDeleted)
@@ -115,14 +115,14 @@ func (broker *Broker) RouterDisconnected(r *network.Router) {
 	}
 }
 
-func (broker *Broker) apiSessionCreated(args ...interface{}) {
+func (broker *Broker) apiSessionFullyAuthenticated(args ...interface{}) {
 	var apiSession *persistence.ApiSession
 	if len(args) == 1 {
 		apiSession, _ = args[0].(*persistence.ApiSession)
 	}
 
 	if apiSession == nil {
-		pfxlog.Logger().Error("during broker apiSessionCreated could not cast arg[0] to *persistence.ApiSession")
+		pfxlog.Logger().Error("during broker apiSessionFullyAuthenticated could not cast arg[0] to *persistence.ApiSession")
 		return
 	}
 	broker.routerSyncStrategy.ApiSessionAdded(apiSession)

--- a/controller/persistence/api_session_store.go
+++ b/controller/persistence/api_session_store.go
@@ -127,7 +127,7 @@ func (store *apiSessionStoreImpl) Update(ctx boltz.MutateContext, entity boltz.E
 
 	if err == nil {
 		if apiSession, ok := entity.(*ApiSession); ok && apiSession != nil {
-			if checker.IsUpdated(FieldApiSessionMfaComplete) && apiSession.MfaComplete == true {
+			if (checker == nil || checker.IsUpdated(FieldApiSessionMfaComplete)) && apiSession.MfaComplete == true {
 				store.Emit(EventFullyAuthenticated, apiSession)
 			}
 		}

--- a/controller/persistence/api_session_store.go
+++ b/controller/persistence/api_session_store.go
@@ -17,6 +17,7 @@
 package persistence
 
 import (
+	"github.com/kataras/go-events"
 	"github.com/openziti/edge/eid"
 	"github.com/openziti/foundation/storage/ast"
 	"github.com/openziti/foundation/storage/boltz"
@@ -32,6 +33,8 @@ const (
 	FieldApiSessionMfaComplete    = "mfaComplete"
 	FieldApiSessionMfaRequired    = "mfaRequired"
 	FieldApiSessionLastActivityAt = "lastActivityAt"
+
+	EventFullyAuthenticated events.EventName = "FULLY_AUTHENTICATED"
 )
 
 type ApiSession struct {
@@ -104,6 +107,33 @@ type apiSessionStoreImpl struct {
 
 	indexToken     boltz.ReadIndex
 	symbolIdentity boltz.EntitySymbol
+}
+
+func (store *apiSessionStoreImpl) Create(ctx boltz.MutateContext, entity boltz.Entity) error {
+	err := store.baseStore.Create(ctx, entity)
+
+	if err == nil {
+		if apiSession, ok := entity.(*ApiSession); ok && apiSession != nil {
+			if apiSession.MfaRequired == false || apiSession.MfaComplete == true {
+				store.Emit(EventFullyAuthenticated, apiSession)
+			}
+		}
+	}
+
+	return err
+}
+func (store *apiSessionStoreImpl) Update(ctx boltz.MutateContext, entity boltz.Entity, checker boltz.FieldChecker) error {
+	err := store.baseStore.Update(ctx, entity, checker)
+
+	if err == nil {
+		if apiSession, ok := entity.(*ApiSession); ok && apiSession != nil {
+			if checker.IsUpdated(FieldApiSessionMfaComplete) && apiSession.MfaComplete == true {
+				store.Emit(EventFullyAuthenticated, apiSession)
+			}
+		}
+	}
+
+	return err
 }
 
 func (store *apiSessionStoreImpl) NewStoreEntity() boltz.Entity {


### PR DESCRIPTION
The previous implementation would send API Sessions to Edge Routers while partially authenticated. Due to state issues addressed separately in the c-SDK, these partial API Sessions are maintained if a channel connected to an edge router was established during reconnect. This would further cause problems with channel connection using the wrong API session vs what the rest of the SDK was using.