### PR TITLE
adds metrics for endpoints with keys of path[method]

### DIFF
--- a/controller/server/client-api.go
+++ b/controller/server/client-api.go
@@ -143,7 +143,6 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 	innerClientHandler := ae.ClientApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s.%s", r.URL.Path, r.Method))
 		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 
@@ -177,6 +176,7 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 		response.AddHeaders(rc)
 
 		innerClientHandler.ServeHTTP(rw, r)
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(r))
 		timer.UpdateSince(start)
 	})
 

--- a/controller/server/client-api.go
+++ b/controller/server/client-api.go
@@ -143,6 +143,8 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 	innerClientHandler := ae.ClientApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s[%s]", r.URL.Path, r.Method))
+		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 
 		//if not /edge prefix and not /fabric, translate to "/edge/client/v<latest>", this is a hack
@@ -175,6 +177,7 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 		response.AddHeaders(rc)
 
 		innerClientHandler.ServeHTTP(rw, r)
+		timer.UpdateSince(start)
 	})
 
 	return api.TimeoutHandler(api.WrapCorsHandler(handler), 10*time.Second, apierror.NewTimeoutError(), response.EdgeResponseMapper{})

--- a/controller/server/client-api.go
+++ b/controller/server/client-api.go
@@ -143,7 +143,7 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 	innerClientHandler := ae.ClientApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s[%s]", r.URL.Path, r.Method))
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s.%s", r.URL.Path, r.Method))
 		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 

--- a/controller/server/management-api.go
+++ b/controller/server/management-api.go
@@ -108,7 +108,7 @@ func (managementApi ManagementApiHandler) newHandler(ae *env.AppEnv) http.Handle
 	innerManagementHandler := ae.ManagementApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s[%s]", r.URL.Path, r.Method))
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s.%s", r.URL.Path, r.Method))
 		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 

--- a/controller/server/management-api.go
+++ b/controller/server/management-api.go
@@ -108,7 +108,6 @@ func (managementApi ManagementApiHandler) newHandler(ae *env.AppEnv) http.Handle
 	innerManagementHandler := ae.ManagementApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(fmt.Sprintf("%s.%s", r.URL.Path, r.Method))
 		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 
@@ -133,8 +132,30 @@ func (managementApi ManagementApiHandler) newHandler(ae *env.AppEnv) http.Handle
 		response.AddHeaders(rc)
 
 		innerManagementHandler.ServeHTTP(rw, r)
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(r))
 		timer.UpdateSince(start)
 	})
 
 	return api.TimeoutHandler(api.WrapCorsHandler(handler), 10*time.Second, apierror.NewTimeoutError(), response.EdgeResponseMapper{})
+}
+
+// getMetricTimerName returns a metric timer name based on the incoming HTTP request's URL and method.
+// Unique ids are removed from the URL and replaced with :id and :subid to group metrics from the same
+// endpoint that happen to be working on different ids.
+func getMetricTimerName(r *http.Request) string {
+	cleanUrl := r.URL.Path
+
+	rc, _ := api.GetRequestContextFromHttpContext(r)
+
+	if rc != nil {
+		if id, err := rc.GetEntityId(); err == nil && id != "" {
+			cleanUrl = strings.Replace(cleanUrl, id, ":id", -1)
+		}
+
+		if subid, err := rc.GetEntitySubId(); err == nil && subid != "" {
+			cleanUrl = strings.Replace(cleanUrl, subid, ":subid", -1)
+		}
+	}
+
+	return fmt.Sprintf("%s.%s", cleanUrl, r.Method)
 }


### PR DESCRIPTION
Example: `/edge/management/v1/authenticate[POST]`