### PR TITLE
moves metric endpoint logging lower in the stack

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -509,8 +509,14 @@ func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestC
 
 		responderFunc(ae, rc)
 
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(rc.Request))
-		timer.UpdateSince(rc.StartTime)
+		if !rc.StartTime.IsZero() {
+			timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(rc.Request))
+			timer.UpdateSince(rc.StartTime)
+		} else {
+			pfxlog.Logger().WithFields(map[string]interface{}{
+				"url": request.URL,
+			}).Warn("could not mark metrics for REST API endpoint, request context start time is zero")
+		}
 	})
 }
 

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -58,6 +58,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -436,6 +437,7 @@ func (ae *AppEnv) CreateRequestContext(rw http.ResponseWriter, r *http.Request) 
 		Identity:          nil,
 		ApiSession:        nil,
 		ActivePermissions: []string{},
+		StartTime:         time.Now(),
 	}
 
 	requestContext.Responder = response.NewResponder(requestContext)
@@ -456,6 +458,27 @@ func GetRequestContextFromHttpContext(r *http.Request) (*response.RequestContext
 	}
 
 	return requestContext, nil
+}
+
+// getMetricTimerName returns a metric timer name based on the incoming HTTP request's URL and method.
+// Unique ids are removed from the URL and replaced with :id and :subid to group metrics from the same
+// endpoint that happen to be working on different ids.
+func getMetricTimerName(r *http.Request) string {
+	cleanUrl := r.URL.Path
+
+	rc, _ := api.GetRequestContextFromHttpContext(r)
+
+	if rc != nil {
+		if id, err := rc.GetEntityId(); err == nil && id != "" {
+			cleanUrl = strings.Replace(cleanUrl, id, ":id", -1)
+		}
+
+		if subid, err := rc.GetEntitySubId(); err == nil && subid != "" {
+			cleanUrl = strings.Replace(cleanUrl, subid, ":subid", -1)
+		}
+	}
+
+	return fmt.Sprintf("%s.%s", cleanUrl, r.Method)
 }
 
 func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestContext), request *http.Request, entityId string, entitySubId string, permissions ...permissions.Resolver) openApiMiddleware.Responder {
@@ -485,6 +508,9 @@ func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestC
 		}
 
 		responderFunc(ae, rc)
+
+		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(rc.Request))
+		timer.UpdateSince(rc.StartTime)
 	})
 }
 

--- a/controller/response/context.go
+++ b/controller/response/context.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"github.com/openziti/edge/controller/model"
 	"net/http"
+	"time"
 )
 
 const (
@@ -39,6 +40,7 @@ type RequestContext struct {
 	entityId          string
 	entitySubId       string
 	Body              []byte
+	StartTime         time.Time
 }
 
 func (rc *RequestContext) GetId() string {

--- a/controller/server/client-api.go
+++ b/controller/server/client-api.go
@@ -143,7 +143,6 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 	innerClientHandler := ae.ClientApi.Serve(nil)
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		start := time.Now()
 		rw.Header().Set(ZitiInstanceId, ae.InstanceId)
 
 		//if not /edge prefix and not /fabric, translate to "/edge/client/v<latest>", this is a hack
@@ -176,8 +175,6 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 		response.AddHeaders(rc)
 
 		innerClientHandler.ServeHTTP(rw, r)
-		timer := ae.GetHostController().GetNetwork().GetMetricsRegistry().Timer(getMetricTimerName(r))
-		timer.UpdateSince(start)
 	})
 
 	return api.TimeoutHandler(api.WrapCorsHandler(handler), 10*time.Second, apierror.NewTimeoutError(), response.EdgeResponseMapper{})


### PR DESCRIPTION
- endpoint url/path -> name remains the same
- start timing on request context before we start processing
- log metrics in IsAllowed which is called by all endpoint after routing
- logging before routing to a handler would log all probe attacks