### PR TITLE
adds.auth.policy.secondary.enforcement

### DIFF
--- a/controller/internal/routes/current_identity_router.go
+++ b/controller/internal/routes/current_identity_router.go
@@ -61,21 +61,21 @@ func (r *CurrentIdentityRouter) Register(ae *env.AppEnv) {
 	})
 
 	ae.ClientApi.CurrentIdentityDetailMfaHandler = clientCurrentIdentity.DetailMfaHandlerFunc(func(params clientCurrentIdentity.DetailMfaParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.detailMfa, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.detailMfa, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ClientApi.CurrentIdentityEnrollMfaHandler = clientCurrentIdentity.EnrollMfaHandlerFunc(func(params clientCurrentIdentity.EnrollMfaParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.createMfa, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.createMfa, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ClientApi.CurrentIdentityVerifyMfaHandler = clientCurrentIdentity.VerifyMfaHandlerFunc(func(params clientCurrentIdentity.VerifyMfaParams, i interface{}) middleware.Responder {
 		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
 			r.verifyMfa(ae, rc, params.MfaValidation)
-		}, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		}, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ClientApi.CurrentIdentityDetailMfaQrCodeHandler = clientCurrentIdentity.DetailMfaQrCodeHandlerFunc(func(params clientCurrentIdentity.DetailMfaQrCodeParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.detailMfaQrCode, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.detailMfaQrCode, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ClientApi.CurrentIdentityCreateMfaRecoveryCodesHandler = clientCurrentIdentity.CreateMfaRecoveryCodesHandlerFunc(func(params clientCurrentIdentity.CreateMfaRecoveryCodesParams, i interface{}) middleware.Responder {
@@ -108,21 +108,21 @@ func (r *CurrentIdentityRouter) Register(ae *env.AppEnv) {
 	})
 
 	ae.ManagementApi.CurrentIdentityDetailMfaHandler = managementCurrentIdentity.DetailMfaHandlerFunc(func(params managementCurrentIdentity.DetailMfaParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.detailMfa, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.detailMfa, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ManagementApi.CurrentIdentityEnrollMfaHandler = managementCurrentIdentity.EnrollMfaHandlerFunc(func(params managementCurrentIdentity.EnrollMfaParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.createMfa, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.createMfa, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ManagementApi.CurrentIdentityVerifyMfaHandler = managementCurrentIdentity.VerifyMfaHandlerFunc(func(params managementCurrentIdentity.VerifyMfaParams, i interface{}) middleware.Responder {
 		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
 			r.verifyMfa(ae, rc, params.MfaValidation)
-		}, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		}, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ManagementApi.CurrentIdentityDetailMfaQrCodeHandler = managementCurrentIdentity.DetailMfaQrCodeHandlerFunc(func(params managementCurrentIdentity.DetailMfaQrCodeParams, i interface{}) middleware.Responder {
-		return ae.IsAllowed(r.detailMfaQrCode, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		return ae.IsAllowed(r.detailMfaQrCode, params.HTTPRequest, "", "", permissions.NewRequireOne(permissions.AuthenticatedPermission, permissions.PartiallyAuthenticatePermission))
 	})
 
 	ae.ManagementApi.CurrentIdentityCreateMfaRecoveryCodesHandler = managementCurrentIdentity.CreateMfaRecoveryCodesHandlerFunc(func(params managementCurrentIdentity.CreateMfaRecoveryCodesParams, i interface{}) middleware.Responder {

--- a/controller/response/context.go
+++ b/controller/response/context.go
@@ -33,6 +33,8 @@ type RequestContext struct {
 	Id                string
 	ApiSession        *model.ApiSession
 	Identity          *model.Identity
+	AuthPolicy        *model.AuthPolicy
+	AuthStatus        AuthStatus
 	ActivePermissions []string
 	ResponseWriter    http.ResponseWriter
 	Request           *http.Request
@@ -41,6 +43,11 @@ type RequestContext struct {
 	entitySubId       string
 	Body              []byte
 	StartTime         time.Time
+}
+
+type AuthStatus struct {
+	SecondaryExtJwtSignerId       string
+	PassedSecondaryExtJwtSignerId bool
 }
 
 func (rc *RequestContext) GetId() string {


### PR DESCRIPTION
- required ext jwt signer requires bearer token on requests
- adds auth query output for ext jwt
- enforces requireTotp auth policy
- allows partial auth to setup MFA but not remove