### PR TITLE
Add.ext.kid.default.migration

### DIFF
--- a/controller/internal/routes/external_jwt_signer_api_model.go
+++ b/controller/internal/routes/external_jwt_signer_api_model.go
@@ -82,6 +82,7 @@ func MapExternalJwtSignerToRestModel(externalJwtSigner *model.ExternalJwtSigner)
 		NotAfter:        &notAfter,
 		NotBefore:       &notBefore,
 		UseExternalID:   &externalJwtSigner.UseExternalId,
+		Kid:             &externalJwtSigner.Kid,
 	}
 	return ret
 }
@@ -95,6 +96,7 @@ func MapCreateExternalJwtSignerToModel(signer *rest_model.ExternalJWTSignerCreat
 		ExternalAuthUrl: signer.ExternalAuthURL,
 		ClaimsProperty:  signer.ClaimsProperty,
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
+		Kid:             *signer.Kid,
 	}
 }
 
@@ -116,6 +118,7 @@ func MapUpdateExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWT
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
 		ClaimsProperty:  signer.ClaimsProperty,
 		ExternalAuthUrl: signer.ExternalAuthURL,
+		Kid:             *signer.Kid,
 	}
 }
 
@@ -137,5 +140,6 @@ func MapPatchExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWTS
 		ExternalAuthUrl: signer.ExternalAuthURL,
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
 		ClaimsProperty:  signer.ClaimsProperty,
+		Kid:             stringz.OrEmpty(signer.Kid),
 	}
 }

--- a/controller/model/external_jwt_signer_model.go
+++ b/controller/model/external_jwt_signer_model.go
@@ -41,6 +41,7 @@ type ExternalJwtSigner struct {
 	Fingerprint string
 	NotAfter    time.Time
 	NotBefore   time.Time
+	Kid         string
 }
 
 func (entity *ExternalJwtSigner) toBoltEntity() (boltz.Entity, error) {
@@ -66,6 +67,7 @@ func (entity *ExternalJwtSigner) toBoltEntity() (boltz.Entity, error) {
 		ExternalAuthUrl: entity.ExternalAuthUrl,
 		UseExternalId:   entity.UseExternalId,
 		ClaimsProperty:  entity.ClaimsProperty,
+		Kid:             entity.Kid,
 	}
 
 	return signer, nil
@@ -88,6 +90,7 @@ func (entity *ExternalJwtSigner) toBoltEntityForPatch(*bbolt.Tx, Handler, boltz.
 		ExternalAuthUrl: entity.ExternalAuthUrl,
 		UseExternalId:   entity.UseExternalId,
 		ClaimsProperty:  entity.ClaimsProperty,
+		Kid:             entity.Kid,
 	}
 
 	if entity.CertPem != "" {
@@ -125,5 +128,6 @@ func (entity *ExternalJwtSigner) fillFrom(_ Handler, _ *bbolt.Tx, boltEntity bol
 	entity.ExternalAuthUrl = boltExternalJwtSigner.ExternalAuthUrl
 	entity.ClaimsProperty = boltExternalJwtSigner.ClaimsProperty
 	entity.UseExternalId = boltExternalJwtSigner.UseExternalId
+	entity.Kid = boltExternalJwtSigner.Kid
 	return nil
 }

--- a/controller/persistence/external_jwt_signer_store.go
+++ b/controller/persistence/external_jwt_signer_store.go
@@ -35,6 +35,7 @@ const (
 	FieldExternalJwtSignerAuthPolicies    = "authPolicies"
 	FieldExternalJwtSignerClaimsProperty  = "claimsProperty"
 	FieldExternalJwtSignerUseExternalId   = "useExternalId"
+	FieldExternalJwtSignerKid             = "kid"
 
 	DefaultClaimsProperty = "sub"
 )
@@ -43,6 +44,7 @@ type ExternalJwtSigner struct {
 	boltz.BaseExtEntity
 	Name            string
 	Fingerprint     string
+	Kid             string
 	CertPem         string
 	CommonName      string
 	NotAfter        *time.Time
@@ -62,6 +64,7 @@ func (entity *ExternalJwtSigner) LoadValues(_ boltz.CrudStore, bucket *boltz.Typ
 	entity.Name = bucket.GetStringWithDefault(FieldName, "")
 	entity.CertPem = bucket.GetStringWithDefault(FieldExternalJwtSignerCertPem, "")
 	entity.Fingerprint = bucket.GetStringWithDefault(FieldExternalJwtSignerFingerprint, "")
+	entity.Kid = bucket.GetStringWithDefault(FieldExternalJwtSignerKid, "")
 	entity.CommonName = bucket.GetStringWithDefault(FieldExternalJwtSignerCommonName, "")
 	entity.NotAfter = bucket.GetTime(FieldExternalJwtSignerNotAfter)
 	entity.NotBefore = bucket.GetTime(FieldExternalJwtSignerNotBefore)
@@ -76,6 +79,7 @@ func (entity *ExternalJwtSigner) SetValues(ctx *boltz.PersistContext) {
 	ctx.SetString(FieldName, entity.Name)
 	ctx.SetString(FieldExternalJwtSignerCertPem, entity.CertPem)
 	ctx.SetString(FieldExternalJwtSignerFingerprint, entity.Fingerprint)
+	ctx.SetString(FieldExternalJwtSignerKid, entity.Kid)
 	ctx.SetString(FieldExternalJwtSignerCommonName, entity.CommonName)
 	ctx.SetTimeP(FieldExternalJwtSignerNotAfter, entity.NotAfter)
 	ctx.SetTimeP(FieldExternalJwtSignerNotBefore, entity.NotBefore)
@@ -117,6 +121,8 @@ type externalJwtSignerStoreImpl struct {
 	symbolEnrollments  boltz.EntitySetSymbol
 	symbolAuthPolicies boltz.EntitySetSymbol
 	fingerprintIndex   boltz.ReadIndex
+	symbolKid          boltz.EntitySymbol
+	kidIndex           boltz.ReadIndex
 }
 
 func (store *externalJwtSignerStoreImpl) NewStoreEntity() boltz.Entity {
@@ -126,10 +132,13 @@ func (store *externalJwtSignerStoreImpl) NewStoreEntity() boltz.Entity {
 func (store *externalJwtSignerStoreImpl) initializeLocal() {
 	store.AddExtEntitySymbols()
 	store.indexName = store.addUniqueNameField()
+
 	store.symbolFingerprint = store.AddSymbol(FieldExternalJwtSignerFingerprint, ast.NodeTypeString)
 	store.fingerprintIndex = store.AddUniqueIndex(store.symbolFingerprint)
 
-	store.AddSymbol(FieldExternalJwtSignerFingerprint, ast.NodeTypeString)
+	store.symbolKid = store.AddSymbol(FieldExternalJwtSignerKid, ast.NodeTypeString)
+	store.kidIndex = store.AddUniqueIndex(store.symbolKid)
+
 	store.AddSymbol(FieldExternalJwtSignerCertPem, ast.NodeTypeString)
 	store.AddSymbol(FieldExternalJwtSignerCommonName, ast.NodeTypeString)
 	store.AddSymbol(FieldExternalJwtSignerNotAfter, ast.NodeTypeDatetime)

--- a/controller/persistence/migration_v25.go
+++ b/controller/persistence/migration_v25.go
@@ -39,10 +39,10 @@ func (m *Migrations) addSystemAuthPolicies(step *boltz.MigrationStep) {
 			Updb: AuthPolicyUpdb{
 				Allowed:            true,
 				MinPasswordLength:  DefaultUpdbMinPasswordLength,
-				RequireSpecialChar: true,
-				RequireNumberChar:  true,
-				RequireMixedCase:   true,
-				MaxAttempts:        5,
+				RequireSpecialChar: false,
+				RequireNumberChar:  false,
+				RequireMixedCase:   false,
+				MaxAttempts:        0,
 			},
 			ExtJwt: AuthPolicyExtJwt{
 				Allowed:              true,

--- a/rest_management_api_server/embedded_spec.go
+++ b/rest_management_api_server/embedded_spec.go
@@ -17233,7 +17233,8 @@ func init() {
     "authPolicySecondary": {
       "type": "object",
       "required": [
-        "requireTotp"
+        "requireTotp",
+        "requireExtJwtSigner"
       ],
       "properties": {
         "requireExtJwtSigner": {
@@ -40042,7 +40043,8 @@ func init() {
     "authPolicySecondary": {
       "type": "object",
       "required": [
-        "requireTotp"
+        "requireTotp",
+        "requireExtJwtSigner"
       ],
       "properties": {
         "requireExtJwtSigner": {

--- a/rest_management_api_server/embedded_spec.go
+++ b/rest_management_api_server/embedded_spec.go
@@ -19041,7 +19041,8 @@ func init() {
       "required": [
         "name",
         "certPem",
-        "enabled"
+        "enabled",
+        "kid"
       ],
       "properties": {
         "certPem": {
@@ -19058,6 +19059,9 @@ func init() {
           "type": "string",
           "format": "url",
           "x-nullable": true
+        },
+        "kid": {
+          "type": "string"
         },
         "name": {
           "type": "string",
@@ -19091,7 +19095,8 @@ func init() {
             "notBefore",
             "externalAuthUrl",
             "claimsProperty",
-            "useExternalId"
+            "useExternalId",
+            "kid"
           ],
           "properties": {
             "certPem": {
@@ -19111,6 +19116,9 @@ func init() {
               "format": "url"
             },
             "fingerprint": {
+              "type": "string"
+            },
+            "kid": {
               "type": "string"
             },
             "name": {
@@ -19159,6 +19167,10 @@ func init() {
           "format": "url",
           "x-nullable": true
         },
+        "kid": {
+          "type": "string",
+          "x-nullable": true
+        },
         "name": {
           "type": "string",
           "x-nullable": true,
@@ -19178,7 +19190,8 @@ func init() {
       "required": [
         "name",
         "certPem",
-        "enabled"
+        "enabled",
+        "kid"
       ],
       "properties": {
         "certPem": {
@@ -19195,6 +19208,9 @@ func init() {
           "type": "string",
           "format": "url",
           "x-nullable": true
+        },
+        "kid": {
+          "type": "string"
         },
         "name": {
           "type": "string",
@@ -41838,7 +41854,8 @@ func init() {
       "required": [
         "name",
         "certPem",
-        "enabled"
+        "enabled",
+        "kid"
       ],
       "properties": {
         "certPem": {
@@ -41855,6 +41872,9 @@ func init() {
           "type": "string",
           "format": "url",
           "x-nullable": true
+        },
+        "kid": {
+          "type": "string"
         },
         "name": {
           "type": "string",
@@ -41888,7 +41908,8 @@ func init() {
             "notBefore",
             "externalAuthUrl",
             "claimsProperty",
-            "useExternalId"
+            "useExternalId",
+            "kid"
           ],
           "properties": {
             "certPem": {
@@ -41908,6 +41929,9 @@ func init() {
               "format": "url"
             },
             "fingerprint": {
+              "type": "string"
+            },
+            "kid": {
               "type": "string"
             },
             "name": {
@@ -41956,6 +41980,10 @@ func init() {
           "format": "url",
           "x-nullable": true
         },
+        "kid": {
+          "type": "string",
+          "x-nullable": true
+        },
         "name": {
           "type": "string",
           "x-nullable": true,
@@ -41975,7 +42003,8 @@ func init() {
       "required": [
         "name",
         "certPem",
-        "enabled"
+        "enabled",
+        "kid"
       ],
       "properties": {
         "certPem": {
@@ -41992,6 +42021,9 @@ func init() {
           "type": "string",
           "format": "url",
           "x-nullable": true
+        },
+        "kid": {
+          "type": "string"
         },
         "name": {
           "type": "string",

--- a/rest_model/auth_policy_secondary.go
+++ b/rest_model/auth_policy_secondary.go
@@ -44,7 +44,8 @@ import (
 type AuthPolicySecondary struct {
 
 	// require ext Jwt signer
-	RequireExtJWTSigner *string `json:"requireExtJwtSigner,omitempty"`
+	// Required: true
+	RequireExtJWTSigner *string `json:"requireExtJwtSigner"`
 
 	// require totp
 	// Required: true
@@ -55,6 +56,10 @@ type AuthPolicySecondary struct {
 func (m *AuthPolicySecondary) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateRequireExtJWTSigner(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRequireTotp(formats); err != nil {
 		res = append(res, err)
 	}
@@ -62,6 +67,15 @@ func (m *AuthPolicySecondary) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *AuthPolicySecondary) validateRequireExtJWTSigner(formats strfmt.Registry) error {
+
+	if err := validate.Required("requireExtJwtSigner", "body", m.RequireExtJWTSigner); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/rest_model/external_jwt_signer_create.go
+++ b/rest_model/external_jwt_signer_create.go
@@ -57,6 +57,10 @@ type ExternalJWTSignerCreate struct {
 	// external auth Url
 	ExternalAuthURL *string `json:"externalAuthUrl,omitempty"`
 
+	// kid
+	// Required: true
+	Kid *string `json:"kid"`
+
 	// name
 	// Example: MyApps Signer
 	// Required: true
@@ -78,6 +82,10 @@ func (m *ExternalJWTSignerCreate) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateEnabled(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateKid(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -107,6 +115,15 @@ func (m *ExternalJWTSignerCreate) validateCertPem(formats strfmt.Registry) error
 func (m *ExternalJWTSignerCreate) validateEnabled(formats strfmt.Registry) error {
 
 	if err := validate.Required("enabled", "body", m.Enabled); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerCreate) validateKid(formats strfmt.Registry) error {
+
+	if err := validate.Required("kid", "body", m.Kid); err != nil {
 		return err
 	}
 

--- a/rest_model/external_jwt_signer_detail.go
+++ b/rest_model/external_jwt_signer_detail.go
@@ -68,6 +68,10 @@ type ExternalJWTSignerDetail struct {
 	// Required: true
 	Fingerprint *string `json:"fingerprint"`
 
+	// kid
+	// Required: true
+	Kid *string `json:"kid"`
+
 	// name
 	// Example: MyApps Signer
 	// Required: true
@@ -111,6 +115,8 @@ func (m *ExternalJWTSignerDetail) UnmarshalJSON(raw []byte) error {
 
 		Fingerprint *string `json:"fingerprint"`
 
+		Kid *string `json:"kid"`
+
 		Name *string `json:"name"`
 
 		NotAfter *strfmt.DateTime `json:"notAfter"`
@@ -134,6 +140,8 @@ func (m *ExternalJWTSignerDetail) UnmarshalJSON(raw []byte) error {
 	m.ExternalAuthURL = dataAO1.ExternalAuthURL
 
 	m.Fingerprint = dataAO1.Fingerprint
+
+	m.Kid = dataAO1.Kid
 
 	m.Name = dataAO1.Name
 
@@ -168,6 +176,8 @@ func (m ExternalJWTSignerDetail) MarshalJSON() ([]byte, error) {
 
 		Fingerprint *string `json:"fingerprint"`
 
+		Kid *string `json:"kid"`
+
 		Name *string `json:"name"`
 
 		NotAfter *strfmt.DateTime `json:"notAfter"`
@@ -188,6 +198,8 @@ func (m ExternalJWTSignerDetail) MarshalJSON() ([]byte, error) {
 	dataAO1.ExternalAuthURL = m.ExternalAuthURL
 
 	dataAO1.Fingerprint = m.Fingerprint
+
+	dataAO1.Kid = m.Kid
 
 	dataAO1.Name = m.Name
 
@@ -235,6 +247,10 @@ func (m *ExternalJWTSignerDetail) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateFingerprint(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateKid(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -308,6 +324,15 @@ func (m *ExternalJWTSignerDetail) validateExternalAuthURL(formats strfmt.Registr
 func (m *ExternalJWTSignerDetail) validateFingerprint(formats strfmt.Registry) error {
 
 	if err := validate.Required("fingerprint", "body", m.Fingerprint); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerDetail) validateKid(formats strfmt.Registry) error {
+
+	if err := validate.Required("kid", "body", m.Kid); err != nil {
 		return err
 	}
 

--- a/rest_model/external_jwt_signer_patch.go
+++ b/rest_model/external_jwt_signer_patch.go
@@ -54,6 +54,9 @@ type ExternalJWTSignerPatch struct {
 	// external auth Url
 	ExternalAuthURL *string `json:"externalAuthUrl,omitempty"`
 
+	// kid
+	Kid *string `json:"kid,omitempty"`
+
 	// name
 	// Example: MyApps Signer
 	Name *string `json:"name,omitempty"`

--- a/rest_model/external_jwt_signer_update.go
+++ b/rest_model/external_jwt_signer_update.go
@@ -57,6 +57,10 @@ type ExternalJWTSignerUpdate struct {
 	// external auth Url
 	ExternalAuthURL *string `json:"externalAuthUrl,omitempty"`
 
+	// kid
+	// Required: true
+	Kid *string `json:"kid"`
+
 	// name
 	// Example: MyApps Signer
 	// Required: true
@@ -78,6 +82,10 @@ func (m *ExternalJWTSignerUpdate) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateEnabled(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateKid(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -107,6 +115,15 @@ func (m *ExternalJWTSignerUpdate) validateCertPem(formats strfmt.Registry) error
 func (m *ExternalJWTSignerUpdate) validateEnabled(formats strfmt.Registry) error {
 
 	if err := validate.Required("enabled", "body", m.Enabled); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerUpdate) validateKid(formats strfmt.Registry) error {
+
+	if err := validate.Required("kid", "body", m.Kid); err != nil {
 		return err
 	}
 

--- a/specs/management.yml
+++ b/specs/management.yml
@@ -13732,6 +13732,7 @@ definitions:
     - name
     - certPem
     - enabled
+    - kid
     properties:
       certPem:
         type: string
@@ -13744,6 +13745,8 @@ definitions:
         type: string
         format: url
         x-nullable: true
+      kid:
+        type: string
       name:
         type: string
         example: MyApps Signer
@@ -13769,6 +13772,7 @@ definitions:
       - externalAuthUrl
       - claimsProperty
       - useExternalId
+      - kid
       properties:
         certPem:
           type: string
@@ -13782,6 +13786,8 @@ definitions:
           type: string
           format: url
         fingerprint:
+          type: string
+        kid:
           type: string
         name:
           type: string
@@ -13815,6 +13821,9 @@ definitions:
         type: string
         format: url
         x-nullable: true
+      kid:
+        type: string
+        x-nullable: true
       name:
         type: string
         x-nullable: true
@@ -13830,6 +13839,7 @@ definitions:
     - name
     - certPem
     - enabled
+    - kid
     properties:
       certPem:
         type: string
@@ -13842,6 +13852,8 @@ definitions:
         type: string
         format: url
         x-nullable: true
+      kid:
+        type: string
       name:
         type: string
         example: MyApps Signer

--- a/specs/management.yml
+++ b/specs/management.yml
@@ -12462,6 +12462,7 @@ definitions:
     type: object
     required:
     - requireTotp
+    - requireExtJwtSigner
     properties:
       requireExtJwtSigner:
         type: string

--- a/specs/source/management/auth-policies.yml
+++ b/specs/source/management/auth-policies.yml
@@ -225,6 +225,7 @@ definitions:
     type: object
     required:
       - requireTotp
+      - requireExtJwtSigner
     properties:
       requireTotp:
         type: boolean

--- a/specs/source/management/ext-jwt-signers.yml
+++ b/specs/source/management/ext-jwt-signers.yml
@@ -177,6 +177,7 @@ definitions:
           - externalAuthUrl
           - claimsProperty
           - useExternalId
+          - kid
         properties:
           name:
             type: string
@@ -202,6 +203,8 @@ definitions:
             type: string
           useExternalId:
             type: boolean
+          kid:
+            type: string
   externalJwtSignerCreate:
     description: A create Certificate Authority (CA) object
     type: object
@@ -209,6 +212,7 @@ definitions:
       - name
       - certPem
       - enabled
+      - kid
     properties:
       name:
         type: string
@@ -221,6 +225,8 @@ definitions:
         type: string
         format: url
         x-nullable: true
+      kid:
+        type: string
       claimsProperty:
         type: string
         x-nullable: true
@@ -235,6 +241,7 @@ definitions:
       - name
       - certPem
       - enabled
+      - kid
     properties:
       name:
         type: string
@@ -243,6 +250,8 @@ definitions:
         type: string
       enabled:
         type: boolean
+      kid:
+        type: string
       externalAuthUrl:
         type: string
         format: url
@@ -267,6 +276,9 @@ definitions:
         x-nullable: true
       enabled:
         type: boolean
+        x-nullable: true
+      kid:
+        type: string
         x-nullable: true
       externalAuthUrl:
         type: string

--- a/tests/auth_policy_test.go
+++ b/tests/auth_policy_test.go
@@ -21,6 +21,7 @@ package tests
 
 import (
 	"github.com/golang-jwt/jwt"
+	"github.com/google/uuid"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/edge/rest_model"
 	nfpem "github.com/openziti/foundation/util/pem"
@@ -55,6 +56,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -245,6 +247,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy Patch"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -350,6 +353,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy Patch1"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -547,6 +551,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert1)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Delete Scenarios 1"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated1 := &rest_model.CreateEnvelope{}
@@ -561,6 +566,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert2)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Delete Scenarios 2"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated2 := &rest_model.CreateEnvelope{}
@@ -807,6 +813,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Update Default"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -925,6 +932,7 @@ func Test_AuthPolicies(t *testing.T) {
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy 08"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -1116,12 +1124,11 @@ func Test_AuthPolicies(t *testing.T) {
 
 			jwtSignerCert, jwtSignerPrivate := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Not Allowed 01")
 
-			jwtSigningCertFingerprint := nfpem.FingerprintFromCertificate(jwtSignerCert)
-
 			extJwtSigner := &rest_model.ExternalJWTSignerCreate{
 				CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 				Enabled: B(true),
 				Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Not Allowed 01"),
+				Kid:     S(uuid.NewString()),
 			}
 
 			extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -1156,7 +1163,7 @@ func Test_AuthPolicies(t *testing.T) {
 				Subject:   identityExtJwtCreated.Data.ID,
 			}
 
-			jwtToken.Header["kid"] = jwtSigningCertFingerprint
+			jwtToken.Header["kid"] = *extJwtSigner.Kid
 
 			jwtStrSigned, err := jwtToken.SignedString(jwtSignerPrivate)
 			ctx.Req.NoError(err)
@@ -1177,12 +1184,11 @@ func Test_AuthPolicies(t *testing.T) {
 
 		jwtSignerCertAllowed, jwtSignerPrivateAllowed := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Allowed 01")
 
-		jwtSigningCertFingerprintAllowed := nfpem.FingerprintFromCertificate(jwtSignerCertAllowed)
-
 		extJwtSignerAllowed := &rest_model.ExternalJWTSignerCreate{
 			CertPem: S(nfpem.EncodeToString(jwtSignerCertAllowed)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 01"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreatedAllowed := &rest_model.CreateEnvelope{}
@@ -1194,12 +1200,11 @@ func Test_AuthPolicies(t *testing.T) {
 
 		jwtSignerCertNotAllowed, jwtSignerPrivateNotAllowed := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Not Allowed 02")
 
-		jwtSigningCertFingerprintNotAllowed := nfpem.FingerprintFromCertificate(jwtSignerCertNotAllowed)
-
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
 			CertPem: S(nfpem.EncodeToString(jwtSignerCertNotAllowed)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 02"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreatedNotAllowed := &rest_model.CreateEnvelope{}
@@ -1273,7 +1278,7 @@ func Test_AuthPolicies(t *testing.T) {
 				Subject:   identityExtJwtCreated.Data.ID,
 			}
 
-			jwtToken.Header["kid"] = jwtSigningCertFingerprintAllowed
+			jwtToken.Header["kid"] = *extJwtSignerAllowed.Kid
 
 			jwtStrSigned, err := jwtToken.SignedString(jwtSignerPrivateAllowed)
 			ctx.Req.NoError(err)
@@ -1300,7 +1305,7 @@ func Test_AuthPolicies(t *testing.T) {
 				Subject:   identityExtJwtCreated.Data.ID,
 			}
 
-			jwtToken.Header["kid"] = jwtSigningCertFingerprintNotAllowed
+			jwtToken.Header["kid"] = *extJwtSigner.Kid
 
 			jwtStrSigned, err := jwtToken.SignedString(jwtSignerPrivateNotAllowed)
 			ctx.Req.NoError(err)
@@ -1319,13 +1324,12 @@ func Test_AuthPolicies(t *testing.T) {
 
 		jwtSignerCertAllowed, validJwtSignerPrivateKey := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT FA 01")
 
-		jwtSigningCertFingerprintAllowed := nfpem.FingerprintFromCertificate(jwtSignerCertAllowed)
-
 		extJwtSignerAllowed := &rest_model.ExternalJWTSignerCreate{
 			CertPem:         S(nfpem.EncodeToString(jwtSignerCertAllowed)),
 			Enabled:         B(true),
 			Name:            S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT FA 01"),
 			ExternalAuthURL: S("https://get.some.jwt.here"),
+			Kid:             S(uuid.NewString()),
 		}
 
 		extJwtSignerCreatedAllowed := &rest_model.CreateEnvelope{}
@@ -1432,7 +1436,7 @@ func Test_AuthPolicies(t *testing.T) {
 					Subject:   identityExtJwtCreated.Data.ID,
 				}
 
-				jwtToken.Header["kid"] = jwtSigningCertFingerprintAllowed
+				jwtToken.Header["kid"] = *extJwtSignerAllowed.Kid
 
 				jwtStrSigned, err := jwtToken.SignedString(validJwtSignerPrivateKey)
 				ctx.Req.NoError(err)

--- a/tests/external_jwt_signer_test.go
+++ b/tests/external_jwt_signer_test.go
@@ -646,6 +646,9 @@ func Test_ExternalJWTSigner(t *testing.T) {
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
 
+			b, _ := jwtSigner.MarshalBinary()
+			println(b)
+
 			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
 			ctx.Req.NoError(err)
 			ctx.Req.Equal(http.StatusCreated, resp.StatusCode())

--- a/tests/external_jwt_signer_test.go
+++ b/tests/external_jwt_signer_test.go
@@ -26,6 +26,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"github.com/google/uuid"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/edge/rest_model"
 	nfpem "github.com/openziti/foundation/util/pem"
@@ -58,6 +59,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			Name:            &jwtSignerName,
 			Tags:            nil,
 			UseExternalID:   B(true),
+			Kid:             S(uuid.New().String()),
 		}
 
 		createResponseEnv := &rest_model.CreateEnvelope{}
@@ -92,6 +94,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				ctx.Req.Equal(*jwtSigner.UseExternalID, *jwtSignerDetail.UseExternalID)
 				ctx.Req.Equal(*jwtSigner.ClaimsProperty, *jwtSignerDetail.ClaimsProperty)
 				ctx.Req.Equal(*jwtSigner.ExternalAuthURL, *jwtSignerDetail.ExternalAuthURL)
+				ctx.Req.Equal(*jwtSigner.Kid, *jwtSignerDetail.Kid)
 			})
 		})
 
@@ -139,11 +142,12 @@ func Test_ExternalJWTSigner(t *testing.T) {
 					CertPem: &jwtSignerCertPem,
 					Enabled: &jwtSignerEnabled,
 					Name:    &jwtSignerName,
+					Kid:     S(uuid.NewString()),
 				}
 
 				resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(putBody).Put("/external-jwt-signers/" + createResponseEnv.Data.ID)
 				ctx.Req.NoError(err)
-				ctx.Req.Equal(resp.StatusCode(), http.StatusNotFound)
+				ctx.Req.Equal(http.StatusNotFound, resp.StatusCode())
 			})
 		})
 	})
@@ -161,6 +165,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			CertPem: &jwtSignerCertPem,
 			Enabled: &jwtSignerEnabled,
 			Name:    &jwtSignerName,
+			Kid:     S(uuid.New().String()),
 		}
 
 		createResponseEnv := &rest_model.CreateEnvelope{}
@@ -212,6 +217,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			jwtSigner := &rest_model.ExternalJWTSignerCreate{
 				Enabled: &jwtSignerEnabled,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -225,6 +231,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			jwtSigner := &rest_model.ExternalJWTSignerCreate{
 				CertPem: &jwtSignerCertPem,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -238,6 +245,21 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			jwtSigner := &rest_model.ExternalJWTSignerCreate{
 				CertPem: &jwtSignerCertPem,
 				Enabled: &jwtSignerEnabled,
+				Kid:     S(uuid.New().String()),
+			}
+
+			createResponseEnv := &rest_model.CreateEnvelope{}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode())
+		})
+
+		t.Run("missing kid", func(t *testing.T) {
+			jwtSigner := &rest_model.ExternalJWTSignerCreate{
+				CertPem: &jwtSignerCertPem,
+				Enabled: &jwtSignerEnabled,
+				Name:    &jwtSignerName,
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -261,6 +283,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				CertPem: &invalidCertPem,
 				Enabled: &jwtSignerEnabled,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			errorResponse := &rest_model.APIErrorEnvelope{}
@@ -271,7 +294,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 		})
 	})
 
-	t.Run("create with re-used signing certificate returns 400 bad request", func(t *testing.T) {
+	t.Run("create with re-used signing certificate/kid fails", func(t *testing.T) {
 		ctx.testContextChanged(t)
 
 		jwtSignerCommonName := "soCommon-dupe1"
@@ -288,6 +311,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			Name:            &jwtSignerName,
 			Tags:            nil,
 			UseExternalID:   B(true),
+			Kid:             S(uuid.New().String()),
 		}
 
 		createResponseEnv := &rest_model.CreateEnvelope{}
@@ -296,7 +320,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
 
-		t.Run("second create fails with 400 bad request", func(t *testing.T) {
+		t.Run("re-used cert fails with 400 bad request", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
 			jwtSignerReusedCert := &rest_model.ExternalJWTSignerCreate{
@@ -307,6 +331,26 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				Name:            S("dupe-should fail"),
 				Tags:            nil,
 				UseExternalID:   B(true),
+				Kid:             S(uuid.New().String()),
+			}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerReusedCert).SetResult(createResponseEnv).Post("/external-jwt-signers")
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode())
+		})
+
+		t.Run("re-used kid create fails with 400 bad request", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			jwtSignerReusedCert := &rest_model.ExternalJWTSignerCreate{
+				CertPem:         &jwtSignerCertPem,
+				ClaimsProperty:  S("whatever"),
+				Enabled:         &jwtSignerEnabled,
+				ExternalAuthURL: S("https://some-other-auth-url"),
+				Name:            S("dupe-should fail"),
+				Tags:            nil,
+				UseExternalID:   B(true),
+				Kid:             jwtSigner.Kid,
 			}
 
 			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerReusedCert).SetResult(createResponseEnv).Post("/external-jwt-signers")
@@ -336,6 +380,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			CertPem: &jwtSignerCertPem,
 			Enabled: &jwtSignerEnabled,
 			Name:    &jwtSignerName,
+			Kid:     S(uuid.New().String()),
 		}
 
 		createResponseEnv := &rest_model.CreateEnvelope{}
@@ -348,6 +393,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 			CertPem: &jwtSignerCertPemUpdated,
 			Enabled: &jwtSignerEnabledUpdated,
 			Name:    &jwtSignerNameUpdated,
+			Kid:     S(uuid.New().String()),
 		}
 
 		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerUpdate).SetResult(createResponseEnv).Put("/external-jwt-signers/" + createResponseEnv.Data.ID)
@@ -377,6 +423,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				ctx.Req.Equal(jwtSignerCertUpdated.NotBefore, time.Time(*jwtSignerDetail.NotBefore))
 				ctx.Req.Equal(jwtSignerCertUpdated.NotAfter, time.Time(*jwtSignerDetail.NotAfter))
 				ctx.Req.Equal(fingerprint, *jwtSignerDetail.Fingerprint)
+				ctx.Req.Equal(*jwtSignerUpdate.Kid, *jwtSignerDetail.Kid)
 			})
 		})
 	})
@@ -401,6 +448,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				CertPem: &jwtSignerCertPem,
 				Enabled: &jwtSignerEnabled,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -442,6 +490,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 					ctx.Req.Equal(jwtSignerCert.NotBefore, time.Time(*jwtSignerDetail.NotBefore))
 					ctx.Req.Equal(jwtSignerCert.NotAfter, time.Time(*jwtSignerDetail.NotAfter))
 					ctx.Req.Equal(fingerprint, *jwtSignerDetail.Fingerprint)
+					ctx.Req.Equal(*jwtSigner.Kid, *jwtSignerDetail.Kid)
 				})
 			})
 		})
@@ -465,6 +514,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				CertPem: &jwtSignerCertPem,
 				Enabled: &jwtSignerEnabled,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -506,6 +556,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 					ctx.Req.Equal(jwtSignerCertPatched.NotBefore, time.Time(*jwtSignerDetail.NotBefore))
 					ctx.Req.Equal(jwtSignerCertPatched.NotAfter, time.Time(*jwtSignerDetail.NotAfter))
 					ctx.Req.Equal(fingerprint, *jwtSignerDetail.Fingerprint)
+					ctx.Req.Equal(*jwtSigner.Kid, *jwtSignerDetail.Kid)
 				})
 			})
 		})
@@ -527,6 +578,7 @@ func Test_ExternalJWTSigner(t *testing.T) {
 				CertPem: &jwtSignerCertPem,
 				Enabled: &jwtSignerEnabled,
 				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
 			}
 
 			createResponseEnv := &rest_model.CreateEnvelope{}
@@ -568,6 +620,70 @@ func Test_ExternalJWTSigner(t *testing.T) {
 					ctx.Req.Equal(jwtSignerCert.NotBefore, time.Time(*jwtSignerDetail.NotBefore))
 					ctx.Req.Equal(jwtSignerCert.NotAfter, time.Time(*jwtSignerDetail.NotAfter))
 					ctx.Req.Equal(fingerprint, *jwtSignerDetail.Fingerprint)
+					ctx.Req.Equal(*jwtSigner.Kid, *jwtSignerDetail.Kid)
+				})
+			})
+		})
+
+		t.Run("kid only succeeds", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			jwtSignerCommonName := "soCommon patch kid"
+
+			jwtSignerCert, _ := newSelfSignedCert(jwtSignerCommonName) // jwtSignerPrivKey
+
+			jwtSignerCertPem := nfpem.EncodeToString(jwtSignerCert)
+
+			jwtSignerName := "Test JWT Signer Pre-Patch Kid"
+
+			jwtSignerEnabled := true
+
+			jwtSigner := &rest_model.ExternalJWTSignerCreate{
+				CertPem: &jwtSignerCertPem,
+				Enabled: &jwtSignerEnabled,
+				Name:    &jwtSignerName,
+				Kid:     S(uuid.New().String()),
+			}
+
+			createResponseEnv := &rest_model.CreateEnvelope{}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+
+			jwtSignerPatch := &rest_model.ExternalJWTSignerPatch{
+				Kid: S(uuid.New().String()),
+			}
+
+			patchResponseEnv := &rest_model.Empty{}
+
+			resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerPatch).SetResult(patchResponseEnv).Patch("/external-jwt-signers/" + createResponseEnv.Data.ID)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+
+			t.Run("get after patch returns 200 Ok", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				jwtSignerDetailEnv := &rest_model.DetailExternalJWTSignerEnvelope{}
+
+				resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(jwtSignerDetailEnv).Get("/external-jwt-signers/" + createResponseEnv.Data.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+
+				jwtSignerDetail := jwtSignerDetailEnv.Data
+
+				t.Run("has the correct value", func(t *testing.T) {
+					ctx.testContextChanged(t)
+
+					fingerprint := nfpem.FingerprintFromCertificate(jwtSignerCert)
+
+					ctx.Req.Equal(jwtSignerName, *jwtSignerDetail.Name)
+					ctx.Req.Equal(jwtSignerCommonName, *jwtSignerDetail.CommonName)
+					ctx.Req.Equal(jwtSignerCertPem, *jwtSignerDetail.CertPem)
+					ctx.Req.Equal(*jwtSigner.Enabled, *jwtSignerDetail.Enabled)
+					ctx.Req.Equal(jwtSignerCert.NotBefore, time.Time(*jwtSignerDetail.NotBefore))
+					ctx.Req.Equal(jwtSignerCert.NotAfter, time.Time(*jwtSignerDetail.NotAfter))
+					ctx.Req.Equal(fingerprint, *jwtSignerDetail.Fingerprint)
+					ctx.Req.Equal(*jwtSignerPatch.Kid, *jwtSignerDetail.Kid)
 				})
 			})
 		})

--- a/tests/identity_test.go
+++ b/tests/identity_test.go
@@ -530,12 +530,11 @@ func Test_Identity(t *testing.T) {
 
 		jwtSignerCert, jwtSignerPrivate := newSelfSignedCert("Test Jwt Signer Cert - Identity Disabled Test 01")
 
-		jwtSigningCertFingerprint := nfpem.FingerprintFromCertificate(jwtSignerCert)
-
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
 			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
 			Enabled: B(true),
 			Name:    S("Test JWT Signer - Auth Policy - Identity Disable Test 01"),
+			Kid:     S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -573,7 +572,7 @@ func Test_Identity(t *testing.T) {
 				Subject:   identityCreated.Data.ID,
 			}
 
-			jwtToken.Header["kid"] = jwtSigningCertFingerprint
+			jwtToken.Header["kid"] = *extJwtSigner.Kid
 
 			jwtStrSigned, err := jwtToken.SignedString(jwtSignerPrivate)
 			ctx.Req.NoError(err)


### PR DESCRIPTION
- adds a mutatable KID value for ext jwt signers. 
- fixes an omitted property on null for auth policies.
- small tweak to default auth policy migration