### PR TITLE
fixes #968 management api doc not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/netfoundry/secretstream v0.1.2
 	github.com/openziti/channel v0.18.27
-	github.com/openziti/fabric v0.17.101
+	github.com/openziti/fabric v0.17.102
 	github.com/openziti/foundation v0.17.22
 	github.com/openziti/sdk-golang v0.16.47
 	github.com/openziti/storage v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -611,8 +611,8 @@ github.com/openziti/channel v0.18.25/go.mod h1:WT35GAbpPEhzwtgEU6KYkStUZVoNuk5XE
 github.com/openziti/channel v0.18.27 h1:g9Iv/1XridsRRdoTXYNKpbSvu8ctXQTbNcnwV/jP5T0=
 github.com/openziti/channel v0.18.27/go.mod h1:YDGdH2I8tJ76WQgHTprgHX6dV9MBlrc1nOYpMY8h8+A=
 github.com/openziti/dilithium v0.3.3/go.mod h1:vsCjI2AU/hon9e+dLhUFbCNGesJDj2ASgkySOcpmvjo=
-github.com/openziti/fabric v0.17.101 h1:KZ4noF+Wk7qrgQ7i3Wc2DMRlb/9f1KS2wJaqZAOaeKY=
-github.com/openziti/fabric v0.17.101/go.mod h1:PBeVP/y/x+ObmSm+0nYoIqVcPhKeU3XBK6ttkjNrwT0=
+github.com/openziti/fabric v0.17.102 h1:oXlmQvCvt3MY/SnUp8GcuGqL7bIWCCkgEN1grF0j+D0=
+github.com/openziti/fabric v0.17.102/go.mod h1:rIY7oVE5ea5mnmbP326v3lgQxJoVQsecwWcm5CSvN1k=
 github.com/openziti/foundation v0.17.22 h1:zFfgNHdLocEcoBqtognpJnYsVQaTm28EwqMNjBw8avk=
 github.com/openziti/foundation v0.17.22/go.mod h1:Nnr0vsqovHJimkdBHf2s4ZJAgvNhg6UdVqP+s0nY3P4=
 github.com/openziti/sdk-golang v0.16.47 h1:mN5gK2+rh7IUZbYYoLW1DnUTlssHaXKtuzP97KQUy8M=

--- a/rest_client_api_server/doc.go
+++ b/rest_client_api_server/doc.go
@@ -29,7 +29,7 @@
 //    https
 //  Host: demo.ziti.dev
 //  BasePath: /edge/client/v1
-//  Version: 0.19.12
+//  Version: 0.25.5
 //  Contact:
 //
 //  Consumes:

--- a/rest_client_api_server/embedded_spec.go
+++ b/rest_client_api_server/embedded_spec.go
@@ -55,7 +55,7 @@ func init() {
   "info": {
     "title": "Ziti Edge Client",
     "contact": {},
-    "version": "0.19.12"
+    "version": "0.25.5"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/client/v1",
@@ -5960,7 +5960,7 @@ func init() {
   "info": {
     "title": "Ziti Edge Client",
     "contact": {},
-    "version": "0.19.12"
+    "version": "0.25.5"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/client/v1",

--- a/rest_management_api_server/doc.go
+++ b/rest_management_api_server/doc.go
@@ -29,7 +29,7 @@
 //    https
 //  Host: demo.ziti.dev
 //  BasePath: /edge/management/v1
-//  Version: 0.19.12
+//  Version: 0.25.5
 //  Contact:
 //
 //  Consumes:

--- a/rest_management_api_server/embedded_spec.go
+++ b/rest_management_api_server/embedded_spec.go
@@ -55,7 +55,7 @@ func init() {
   "info": {
     "title": "Ziti Edge Management",
     "contact": {},
-    "version": "0.19.12"
+    "version": "0.25.5"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/management/v1",
@@ -22807,7 +22807,7 @@ func init() {
   "info": {
     "title": "Ziti Edge Management",
     "contact": {},
-    "version": "0.19.12"
+    "version": "0.25.5"
   },
   "host": "demo.ziti.dev",
   "basePath": "/edge/management/v1",

--- a/specs/client.yml
+++ b/specs/client.yml
@@ -8,7 +8,7 @@ swagger: "2.0"
 info:
   title: Ziti Edge Client
   contact: {}
-  version: 0.19.12
+  version: 0.25.5
 host: demo.ziti.dev
 basePath: /edge/client/v1
 paths:

--- a/specs/management.yml
+++ b/specs/management.yml
@@ -8,7 +8,7 @@ swagger: "2.0"
 info:
   title: Ziti Edge Management
   contact: {}
-  version: 0.19.12
+  version: 0.25.5
 host: demo.ziti.dev
 basePath: /edge/management/v1
 paths:

--- a/specs/source/client.yml
+++ b/specs/source/client.yml
@@ -1,7 +1,7 @@
 ---
 swagger: '2.0'
 info:
-  version: 0.19.12
+  version: 0.25.5
   title: Ziti Edge Client
   contact: { }
 host: demo.ziti.dev

--- a/specs/source/management.yml
+++ b/specs/source/management.yml
@@ -1,7 +1,7 @@
 ---
 swagger: '2.0'
 info:
-  version: 0.19.12
+  version: 0.25.5
   title: Ziti Edge Management
   contact: {}
 host: demo.ziti.dev


### PR DESCRIPTION
Root cause is a bug and/or lack of features in the go-open-api runtime.