### PR TITLE
adds jwks support

### DIFF
--- a/controller/internal/routes/external_jwt_signer_api_model.go
+++ b/controller/internal/routes/external_jwt_signer_api_model.go
@@ -72,36 +72,49 @@ func MapExternalJwtSignerToRestModel(externalJwtSigner *model.ExternalJwtSigner)
 
 	ret := &rest_model.ExternalJWTSignerDetail{
 		BaseEntity:      BaseEntityToRestModel(externalJwtSigner, ExternalJwtSignerLinkFactory),
-		CertPem:         &externalJwtSigner.CertPem,
 		ClaimsProperty:  externalJwtSigner.ClaimsProperty,
 		CommonName:      &externalJwtSigner.CommonName,
 		Enabled:         &externalJwtSigner.Enabled,
 		ExternalAuthURL: externalJwtSigner.ExternalAuthUrl,
-		Fingerprint:     &externalJwtSigner.Fingerprint,
+		Fingerprint:     externalJwtSigner.Fingerprint,
 		Name:            &externalJwtSigner.Name,
 		NotAfter:        &notAfter,
 		NotBefore:       &notBefore,
 		UseExternalID:   &externalJwtSigner.UseExternalId,
-		Kid:             &externalJwtSigner.Kid,
+		Kid:             externalJwtSigner.Kid,
 		Issuer:          externalJwtSigner.Issuer,
 		Audience:        externalJwtSigner.Audience,
+		CertPem:         externalJwtSigner.CertPem,
 	}
+
+	if externalJwtSigner.JwksEndpoint != nil {
+		jwks := strfmt.URI(*externalJwtSigner.JwksEndpoint)
+		ret.JwksEndpoint = &jwks
+	}
+
 	return ret
 }
 
 func MapCreateExternalJwtSignerToModel(signer *rest_model.ExternalJWTSignerCreate) *model.ExternalJwtSigner {
-	return &model.ExternalJwtSigner{
+	ret := &model.ExternalJwtSigner{
 		BaseEntity:      models.BaseEntity{},
 		Name:            *signer.Name,
-		CertPem:         *signer.CertPem,
 		Enabled:         *signer.Enabled,
 		ExternalAuthUrl: signer.ExternalAuthURL,
 		ClaimsProperty:  signer.ClaimsProperty,
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
-		Kid:             *signer.Kid,
+		Kid:             signer.Kid,
 		Issuer:          signer.Issuer,
 		Audience:        signer.Audience,
+		CertPem:         signer.CertPem,
 	}
+
+	if signer.JwksEndpoint != nil {
+		jwksEndpoint := signer.JwksEndpoint.String()
+		ret.JwksEndpoint = &jwksEndpoint
+	}
+
+	return ret
 }
 
 func MapUpdateExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWTSignerUpdate) *model.ExternalJwtSigner {
@@ -110,22 +123,29 @@ func MapUpdateExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWT
 		tags = signer.Tags.SubTags
 	}
 
-	return &model.ExternalJwtSigner{
+	ret := &model.ExternalJwtSigner{
 		BaseEntity: models.BaseEntity{
 			Id:       id,
 			Tags:     tags,
 			IsSystem: false,
 		},
 		Name:            *signer.Name,
-		CertPem:         *signer.CertPem,
+		CertPem:         signer.CertPem,
 		Enabled:         *signer.Enabled,
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
 		ClaimsProperty:  signer.ClaimsProperty,
 		ExternalAuthUrl: signer.ExternalAuthURL,
-		Kid:             *signer.Kid,
+		Kid:             signer.Kid,
 		Issuer:          signer.Issuer,
 		Audience:        signer.Audience,
 	}
+
+	if signer.JwksEndpoint != nil {
+		jwksEndpoint := signer.JwksEndpoint.String()
+		ret.JwksEndpoint = &jwksEndpoint
+	}
+
+	return ret
 }
 
 func MapPatchExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWTSignerPatch) *model.ExternalJwtSigner {
@@ -134,20 +154,27 @@ func MapPatchExternalJwtSignerToModel(id string, signer *rest_model.ExternalJWTS
 		tags = signer.Tags.SubTags
 	}
 
-	return &model.ExternalJwtSigner{
+	ret := &model.ExternalJwtSigner{
 		BaseEntity: models.BaseEntity{
 			Id:       id,
 			Tags:     tags,
 			IsSystem: false,
 		},
 		Name:            stringz.OrEmpty(signer.Name),
-		CertPem:         stringz.OrEmpty(signer.CertPem),
+		CertPem:         signer.CertPem,
 		Enabled:         BoolOrDefault(signer.Enabled),
 		ExternalAuthUrl: signer.ExternalAuthURL,
 		UseExternalId:   BoolOrDefault(signer.UseExternalID),
 		ClaimsProperty:  signer.ClaimsProperty,
-		Kid:             stringz.OrEmpty(signer.Kid),
+		Kid:             signer.Kid,
 		Issuer:          signer.Issuer,
 		Audience:        signer.Audience,
 	}
+
+	if signer.JwksEndpoint != nil {
+		jwksEndpoint := signer.JwksEndpoint.String()
+		ret.JwksEndpoint = &jwksEndpoint
+	}
+
+	return ret
 }

--- a/controller/model/authenticator_mod_ext_jwt_test.go
+++ b/controller/model/authenticator_mod_ext_jwt_test.go
@@ -1,0 +1,97 @@
+package model
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"github.com/Jeffail/gabs/v2"
+	"github.com/openziti/edge/controller/persistence"
+	"github.com/openziti/jwks"
+	"github.com/openziti/storage/boltz"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var testJkws = `{
+    "keys": [
+        {
+            "alg": "RS256",
+            "kty": "RSA",
+            "use": "sig",
+            "n": "4SEOORSe1V6Ic-_LSbFJaERGxTwBhHt2zHluYO449sYEi7um4Q-ZodseaUw4R1uLvIG_Eh7mJwGi37-To8woYzCLz3fvdF7G5Pq-tm78A4VLC9_WrvBOgP9PXYaGzPcz60JTJb5Ee94jrWYVwLJUGX_AXnjKUAJXFhAVGlrpeCRMhJx625XIQEchNjdotMxe_kPwM9dgmG_zRe0IH98UbuqYTYUwdkH_INe7IL7jJF3tDm2571yAbH_unqdpTvrrb3CkU0f-AIwb-GlYxR2aQ8jNaGGJSx0EI_G89BHMZAGJpRlPXwjD5qrn2QC06XOG9JDrLyDen2Z2R-TYCfkkjw",
+            "e": "AQAB",
+            "kid": "nDNaLwW5uTxoHZ5vLiTui",
+            "x5t": "MMp-6VIvEYOnYoGjvky-Wxk_h0A",
+            "x5c": [
+                "MIIDDTCCAfWgAwIBAgIJZgHXXsVCojHCMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNVBAMTGWRldi1qYTI4b2p6ay51cy5hdXRoMC5jb20wHhcNMjIwMzAzMTgxNjM4WhcNMzUxMTEwMTgxNjM4WjAkMSIwIAYDVQQDExlkZXYtamEyOG9qemsudXMuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4SEOORSe1V6Ic+/LSbFJaERGxTwBhHt2zHluYO449sYEi7um4Q+ZodseaUw4R1uLvIG/Eh7mJwGi37+To8woYzCLz3fvdF7G5Pq+tm78A4VLC9/WrvBOgP9PXYaGzPcz60JTJb5Ee94jrWYVwLJUGX/AXnjKUAJXFhAVGlrpeCRMhJx625XIQEchNjdotMxe/kPwM9dgmG/zRe0IH98UbuqYTYUwdkH/INe7IL7jJF3tDm2571yAbH/unqdpTvrrb3CkU0f+AIwb+GlYxR2aQ8jNaGGJSx0EI/G89BHMZAGJpRlPXwjD5qrn2QC06XOG9JDrLyDen2Z2R+TYCfkkjwIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRrO/lcE6fRDss+WAroJw0I3sZQ1zAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAChrBHmfIbEOOKdtOs5zfLgZKjwXMQ3NydYHSCPrZKKNrR2JLYRy3KD3iLUZmqgb3kiWqO+aVABAHNi3H3oGTTIEklRH69NMpbmTs+W9suw/JaIrbj2HCPbTCGMvA5yTo3kABJbVapHCO8cd8FCZVCa5+CbdMBsjvnZvUNriX69VAHIzRIv/AGQbHXWQoU7igRm9nLnO/BKFhWPXiSuYpaBz5uqg+qB3gfyGUQjeAoYo5b3YtZt/GrwcQS5Ku4lhV7jPkAgEyQdHAC6RKw7Gf/p+u58gSMKXeZxW9FxgGNMsQPuKTyIEuikYinT70Y1IUsMAaqS5SrzglvPYgZpYTmc="
+            ]
+        },
+        {
+            "alg": "RS256",
+            "kty": "RSA",
+            "use": "sig",
+            "n": "-VLOzBGDO1mRgwz6ZWK4aTyebQI5blRifFrhjax-bH_hbFaNZ1LjFZNUJ7wR1GfrXUtI_2bZF-QBeGPD_rfwrPuAVktyysGWpyTeTUJSbdotWyhDN7v6_ySvQcLjQVajRslGiUUn9eBNDvQm8HyAgmUEOFZk5m0kdSh2sU3fB-Q71OGYHm_uTSENGgtnVp7pvXJVoD26-ZKf_6movrrQ8lPX_SBFL79JIGwcV-Q35PkwKpLDmfR5qsiruQcgAOrcU83UEujrHumgJFM2SV_7pP1lW83itYBizeShUXDkMnEsarenNwBs2ej4CHF4wlg8kvAuvM1etP9wTvQgR8pCTw",
+            "e": "AQAB",
+            "kid": "9OcLRMTskCwYepHJAgyc4",
+            "x5t": "AQFCuQ1CEs-mkKBan4LOQS0AsbM",
+            "x5c": [
+                "MIIDDTCCAfWgAwIBAgIJUE+YLL7UA3KIMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNVBAMTGWRldi1qYTI4b2p6ay51cy5hdXRoMC5jb20wHhcNMjIwMzAzMTgxNjM4WhcNMzUxMTEwMTgxNjM4WjAkMSIwIAYDVQQDExlkZXYtamEyOG9qemsudXMuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+VLOzBGDO1mRgwz6ZWK4aTyebQI5blRifFrhjax+bH/hbFaNZ1LjFZNUJ7wR1GfrXUtI/2bZF+QBeGPD/rfwrPuAVktyysGWpyTeTUJSbdotWyhDN7v6/ySvQcLjQVajRslGiUUn9eBNDvQm8HyAgmUEOFZk5m0kdSh2sU3fB+Q71OGYHm/uTSENGgtnVp7pvXJVoD26+ZKf/6movrrQ8lPX/SBFL79JIGwcV+Q35PkwKpLDmfR5qsiruQcgAOrcU83UEujrHumgJFM2SV/7pP1lW83itYBizeShUXDkMnEsarenNwBs2ej4CHF4wlg8kvAuvM1etP9wTvQgR8pCTwIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSwhiE0zXOLZkCeCDIibq6gx1x9VzAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAMyRiIbglAop3eSX/DzS27OJe2vVMd9pCUBV/WeCSIt41Cv1ZHW15sklCyr5mGN27MrYK50h/vb4JcHRTLrUZ2L0Ib5ogcxeQTWzTpcK8VEKT4bUZhJeOoqWxjBEZi/mo8EqadY0NMzEy0mAUTJzOtfJv8eSoRE1ElwTb6AQiTFLHtcK2MLEDWNIXWVOVew5OTVRJLJd4r5jgL9DcuVFY/sWLn7LgV71P9bjZnvGx8FuWouYsnjMT/YhfUhs+n+JPCX7SEHn3rn5XXGN6KyEYzBLrouQHRu+y3x7aYCWwW1Hr94EbvGaD/dSzH+zAMmk635mrmM1JXXYGeIVp0xKP5s="
+            ]
+        }
+    ]
+}`
+
+type staticJwksResponder struct {
+	payload       string
+	called        bool
+	calledWithUrl string
+}
+
+func (s *staticJwksResponder) Get(url string) (*jwks.Response, []byte, error) {
+	s.called = true
+	s.calledWithUrl = url
+
+	jwksResponse := &jwks.Response{}
+	if err := json.Unmarshal([]byte(s.payload), jwksResponse); err != nil {
+		return nil, nil, err
+	}
+
+	return jwksResponse, []byte(testJkws), nil
+}
+
+func Test_signerRecord_Resolve(t *testing.T) {
+	jwksContainer, err := gabs.ParseJSON([]byte(testJkws))
+	require.NoError(t, err)
+	require.NotNil(t, jwksContainer)
+
+	t.Run("can resolve and parse a valid JWKS response", func(t *testing.T) {
+		req := require.New(t)
+
+		jwksEndpoint := "https://example.com/.well-known/jwks"
+
+		jwksResolver := &staticJwksResponder{
+			payload: testJkws,
+		}
+
+		signerRec := &signerRecord{
+			kidToCertificate: map[string]*x509.Certificate{},
+			externalJwtSigner: &persistence.ExternalJwtSigner{
+				BaseExtEntity: boltz.BaseExtEntity{
+					Id:        "fake-id",
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name:         "test1",
+				JwksEndpoint: &jwksEndpoint,
+				Enabled:      true,
+			},
+			jwksResolver: jwksResolver,
+		}
+
+		req.NoError(signerRec.Resolve(false))
+		req.True(jwksResolver.called)
+		req.Equal(jwksEndpoint, jwksResolver.calledWithUrl)
+		req.Len(signerRec.kidToCertificate, 2)
+
+	})
+}

--- a/controller/model/external_jwt_signer_handlers.go
+++ b/controller/model/external_jwt_signer_handlers.go
@@ -42,8 +42,8 @@ func (handler *ExternalJwtSignerHandler) newModelEntity() boltEntitySink {
 	return &ExternalJwtSigner{}
 }
 
-func (handler *ExternalJwtSignerHandler) Create(ExternalJwtSignerModel *ExternalJwtSigner) (string, error) {
-	return handler.createEntity(ExternalJwtSignerModel)
+func (handler *ExternalJwtSignerHandler) Create(model *ExternalJwtSigner) (string, error) {
+	return handler.createEntity(model)
 }
 
 func (handler *ExternalJwtSignerHandler) Read(id string) (*ExternalJwtSigner, error) {
@@ -54,12 +54,12 @@ func (handler *ExternalJwtSignerHandler) Read(id string) (*ExternalJwtSigner, er
 	return modelEntity, nil
 }
 
-func (handler *ExternalJwtSignerHandler) Update(signer *ExternalJwtSigner) error {
-	return handler.updateEntity(signer, handler)
+func (handler *ExternalJwtSignerHandler) Update(model *ExternalJwtSigner) error {
+	return handler.updateEntity(model, handler)
 }
 
-func (handler *ExternalJwtSignerHandler) Patch(signer *ExternalJwtSigner, fields boltz.FieldChecker) error {
-	return handler.patchEntity(signer, fields)
+func (handler *ExternalJwtSignerHandler) Patch(model *ExternalJwtSigner, fields boltz.FieldChecker) error {
+	return handler.patchEntity(model, fields)
 }
 
 func (handler *ExternalJwtSignerHandler) Delete(id string) error {

--- a/controller/model/external_jwt_signer_model.go
+++ b/controller/model/external_jwt_signer_model.go
@@ -17,6 +17,7 @@
 package model
 
 import (
+	"crypto/x509"
 	"github.com/openziti/edge/controller/apierror"
 	"github.com/openziti/edge/controller/persistence"
 	"github.com/openziti/fabric/controller/models"
@@ -31,8 +32,9 @@ import (
 type ExternalJwtSigner struct {
 	models.BaseEntity
 	Name            string
-	CertPem         string
-	Kid             string
+	CertPem         *string
+	JwksEndpoint    *string
+	Kid             *string
 	Enabled         bool
 	ExternalAuthUrl *string
 	UseExternalId   bool
@@ -41,30 +43,32 @@ type ExternalJwtSigner struct {
 	Audience        *string
 
 	CommonName  string
-	Fingerprint string
+	Fingerprint *string
 	NotAfter    time.Time
 	NotBefore   time.Time
 }
 
 func (entity *ExternalJwtSigner) toBoltEntity() (boltz.Entity, error) {
-	signerCerts := nfpem.PemStringToCertificates(entity.CertPem)
+	var fingerprint string
+	var signerCert *x509.Certificate
 
-	if len(signerCerts) != 1 {
-		return nil, apierror.NewInvalidCertificatePem()
+	if entity.CertPem != nil {
+		signerCerts := nfpem.PemStringToCertificates(*entity.CertPem)
+		if len(signerCerts) != 1 {
+			return nil, apierror.NewInvalidCertificatePem()
+		}
+
+		signerCert = signerCerts[0]
+
+		fingerprint = nfpem.FingerprintFromCertificate(signerCert)
 	}
-
-	signerCert := signerCerts[0]
-
-	fingerprint := nfpem.FingerprintFromCertificate(signerCert)
 
 	signer := &persistence.ExternalJwtSigner{
 		BaseExtEntity:   *boltz.NewExtEntity(entity.Id, entity.Tags),
 		Name:            entity.Name,
-		Fingerprint:     fingerprint,
+		Fingerprint:     &fingerprint,
 		CertPem:         entity.CertPem,
-		CommonName:      signerCert.Subject.CommonName,
-		NotAfter:        &signerCert.NotAfter,
-		NotBefore:       &signerCert.NotBefore,
+		JwksEndpoint:    entity.JwksEndpoint,
 		Enabled:         entity.Enabled,
 		ExternalAuthUrl: entity.ExternalAuthUrl,
 		UseExternalId:   entity.UseExternalId,
@@ -72,6 +76,12 @@ func (entity *ExternalJwtSigner) toBoltEntity() (boltz.Entity, error) {
 		Kid:             entity.Kid,
 		Issuer:          entity.Issuer,
 		Audience:        entity.Audience,
+	}
+
+	if entity.CertPem != nil {
+		signer.CommonName = signerCert.Subject.CommonName
+		signer.NotAfter = &signerCert.NotAfter
+		signer.NotBefore = &signerCert.NotBefore
 	}
 
 	return signer, nil
@@ -90,6 +100,7 @@ func (entity *ExternalJwtSigner) toBoltEntityForPatch(*bbolt.Tx, EntityManager, 
 		BaseExtEntity:   *boltz.NewExtEntity(entity.Id, entity.Tags),
 		Name:            entity.Name,
 		CertPem:         entity.CertPem,
+		JwksEndpoint:    entity.JwksEndpoint,
 		Enabled:         entity.Enabled,
 		ExternalAuthUrl: entity.ExternalAuthUrl,
 		UseExternalId:   entity.UseExternalId,
@@ -99,8 +110,8 @@ func (entity *ExternalJwtSigner) toBoltEntityForPatch(*bbolt.Tx, EntityManager, 
 		Audience:        entity.Issuer,
 	}
 
-	if entity.CertPem != "" {
-		signerCerts := nfpem.PemStringToCertificates(entity.CertPem)
+	if entity.CertPem != nil && *entity.CertPem != "" {
+		signerCerts := nfpem.PemStringToCertificates(*entity.CertPem)
 
 		if len(signerCerts) != 1 {
 			return nil, apierror.NewInvalidCertificatePem()
@@ -112,7 +123,7 @@ func (entity *ExternalJwtSigner) toBoltEntityForPatch(*bbolt.Tx, EntityManager, 
 		signer.CommonName = signerCert.Subject.CommonName
 		signer.NotBefore = &signerCert.NotBefore
 		signer.NotAfter = &signerCert.NotAfter
-		signer.Fingerprint = fingerprint
+		signer.Fingerprint = &fingerprint
 	}
 
 	return signer, nil
@@ -127,6 +138,7 @@ func (entity *ExternalJwtSigner) fillFrom(_ EntityManager, _ *bbolt.Tx, boltEnti
 	entity.Name = boltExternalJwtSigner.Name
 	entity.CommonName = boltExternalJwtSigner.CommonName
 	entity.CertPem = boltExternalJwtSigner.CertPem
+	entity.JwksEndpoint = boltExternalJwtSigner.JwksEndpoint
 	entity.Fingerprint = boltExternalJwtSigner.Fingerprint
 	entity.Enabled = boltExternalJwtSigner.Enabled
 	entity.NotBefore = *boltExternalJwtSigner.NotBefore

--- a/controller/model/posture_check_model_process_multi_test.go
+++ b/controller/model/posture_check_model_process_multi_test.go
@@ -117,7 +117,7 @@ func TestPostureCheckModelProcessMulti_Evaluate(t *testing.T) {
 		req.False(result)
 	})
 
-	t.Run("returns false if signers do not match", func(t *testing.T) {
+	t.Run("returns false if signerByIssuer do not match", func(t *testing.T) {
 		processCheck, postureData := newMatchingProcessMultiCheckAndData()
 		postureData.Processes[0].SignerFingerprints = []string{"does not match"}
 

--- a/controller/model/posture_check_model_process_test.go
+++ b/controller/model/posture_check_model_process_test.go
@@ -116,7 +116,7 @@ func TestPostureCheckModelProcess_Evaluate(t *testing.T) {
 		req.False(result)
 	})
 
-	t.Run("returns false if signers do not match", func(t *testing.T) {
+	t.Run("returns false if signerByIssuer do not match", func(t *testing.T) {
 		processCheck, postureData := newMatchingProcessCheckAndData()
 		postureData.Processes[0].SignerFingerprints = []string{"does not match"}
 

--- a/controller/model/posture_response_model_process.go
+++ b/controller/model/posture_response_model_process.go
@@ -86,7 +86,7 @@ func (pr *PostureResponseProcess) VerifyMultiCriteria(process *ProcessMulti) boo
 	foundValidSigner := false
 
 	if len(process.SignerFingerprints) == 0 {
-		foundValidSigner = true //no signers to check for
+		foundValidSigner = true //no signerByIssuer to check for
 	} else {
 		for _, validSigner := range process.SignerFingerprints {
 			validSigner := strings.ToLower(validSigner)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/AppsFlyer/go-sundheit v0.5.0
 	github.com/Jeffail/gabs v1.4.0
+	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/coreos/go-iptables v0.6.0
@@ -34,6 +35,7 @@ require (
 	github.com/openziti/channel v0.18.39
 	github.com/openziti/fabric v0.18.1
 	github.com/openziti/foundation v0.17.27
+	github.com/openziti/jwks v1.0.1
 	github.com/openziti/sdk-golang v0.16.76
 	github.com/openziti/storage v0.1.7
 	github.com/openziti/transport/v2 v2.0.4
@@ -61,7 +63,6 @@ require (
 )
 
 require (
-	github.com/Jeffail/gabs/v2 v2.6.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211106181442-e4c1a74c66bd // indirect
 	github.com/armon/go-metrics v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/openziti/fabric v0.18.1 h1:ftZUBy9DwM8JEI1Z1wjfgkDuXEAoGAE9gXUrG8R71Q
 github.com/openziti/fabric v0.18.1/go.mod h1:Nr4nM6TfL1EsQoPEismBEErmz15miIngR9rCgkG8j0k=
 github.com/openziti/foundation v0.17.27 h1:RKvHQHNIxfME0LnxB+LF14HS19V+wE3NvSse0G5fnAE=
 github.com/openziti/foundation v0.17.27/go.mod h1:obk269ZljgJzdziLAHcoAW+otWSqGYH57XupgkiIsj0=
+github.com/openziti/jwks v1.0.1 h1:+BtBzDWFVUlJfCbBhQR0BZI3YNtoBvfhfdCUSSB0G+0=
+github.com/openziti/jwks v1.0.1/go.mod h1:KwO0x9FBG0aoJS5f6nH5xeHoplyR1H143SMI9kF0mC8=
 github.com/openziti/sdk-golang v0.16.76 h1:/RuuZQGnGNuLBgFuW17t903s1EKh7TPn9ysm6tEuKIo=
 github.com/openziti/sdk-golang v0.16.76/go.mod h1:YsuGyHDMJh0UdPHAQUOB1OHV3c+xkwYs5JoYK/vPJiI=
 github.com/openziti/storage v0.1.7 h1:g8iBcscDF+EzgGYDm9MKNRKK3xuS1AWPe9dMLJHN32U=

--- a/rest_management_api_server/embedded_spec.go
+++ b/rest_management_api_server/embedded_spec.go
@@ -19380,9 +19380,9 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "certPem",
         "enabled",
-        "kid"
+        "issuer",
+        "audience"
       ],
       "properties": {
         "audience": {
@@ -19390,7 +19390,8 @@ func init() {
           "x-nullable": true
         },
         "certPem": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "claimsProperty": {
           "type": "string",
@@ -19405,11 +19406,16 @@ func init() {
           "x-nullable": true
         },
         "issuer": {
+          "type": "string"
+        },
+        "jwksEndpoint": {
           "type": "string",
+          "format": "uri",
           "x-nullable": true
         },
         "kid": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "name": {
           "type": "string",
@@ -19436,6 +19442,7 @@ func init() {
           "required": [
             "name",
             "certPem",
+            "jwksEndpoint",
             "enabled",
             "fingerprint",
             "commonName",
@@ -19453,7 +19460,8 @@ func init() {
               "type": "string"
             },
             "certPem": {
-              "type": "string"
+              "type": "string",
+              "x-nullable": true
             },
             "claimsProperty": {
               "type": "string"
@@ -19473,6 +19481,11 @@ func init() {
             },
             "issuer": {
               "type": "string"
+            },
+            "jwksEndpoint": {
+              "type": "string",
+              "format": "uri",
+              "x-nullable": true
             },
             "kid": {
               "type": "string"
@@ -19531,6 +19544,11 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "jwksEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "x-nullable": true
+        },
         "kid": {
           "type": "string",
           "x-nullable": true
@@ -19553,9 +19571,9 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "certPem",
         "enabled",
-        "kid"
+        "issuer",
+        "audience"
       ],
       "properties": {
         "audience": {
@@ -19563,7 +19581,8 @@ func init() {
           "x-nullable": true
         },
         "certPem": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "claimsProperty": {
           "type": "string",
@@ -19578,11 +19597,16 @@ func init() {
           "x-nullable": true
         },
         "issuer": {
+          "type": "string"
+        },
+        "jwksEndpoint": {
           "type": "string",
+          "format": "uri",
           "x-nullable": true
         },
         "kid": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "name": {
           "type": "string",
@@ -42589,9 +42613,9 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "certPem",
         "enabled",
-        "kid"
+        "issuer",
+        "audience"
       ],
       "properties": {
         "audience": {
@@ -42599,7 +42623,8 @@ func init() {
           "x-nullable": true
         },
         "certPem": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "claimsProperty": {
           "type": "string",
@@ -42614,11 +42639,16 @@ func init() {
           "x-nullable": true
         },
         "issuer": {
+          "type": "string"
+        },
+        "jwksEndpoint": {
           "type": "string",
+          "format": "uri",
           "x-nullable": true
         },
         "kid": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "name": {
           "type": "string",
@@ -42645,6 +42675,7 @@ func init() {
           "required": [
             "name",
             "certPem",
+            "jwksEndpoint",
             "enabled",
             "fingerprint",
             "commonName",
@@ -42662,7 +42693,8 @@ func init() {
               "type": "string"
             },
             "certPem": {
-              "type": "string"
+              "type": "string",
+              "x-nullable": true
             },
             "claimsProperty": {
               "type": "string"
@@ -42682,6 +42714,11 @@ func init() {
             },
             "issuer": {
               "type": "string"
+            },
+            "jwksEndpoint": {
+              "type": "string",
+              "format": "uri",
+              "x-nullable": true
             },
             "kid": {
               "type": "string"
@@ -42740,6 +42777,11 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "jwksEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "x-nullable": true
+        },
         "kid": {
           "type": "string",
           "x-nullable": true
@@ -42762,9 +42804,9 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "certPem",
         "enabled",
-        "kid"
+        "issuer",
+        "audience"
       ],
       "properties": {
         "audience": {
@@ -42772,7 +42814,8 @@ func init() {
           "x-nullable": true
         },
         "certPem": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "claimsProperty": {
           "type": "string",
@@ -42787,11 +42830,16 @@ func init() {
           "x-nullable": true
         },
         "issuer": {
+          "type": "string"
+        },
+        "jwksEndpoint": {
           "type": "string",
+          "format": "uri",
           "x-nullable": true
         },
         "kid": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "name": {
           "type": "string",

--- a/rest_model/external_jwt_signer_create.go
+++ b/rest_model/external_jwt_signer_create.go
@@ -44,11 +44,11 @@ import (
 type ExternalJWTSignerCreate struct {
 
 	// audience
-	Audience *string `json:"audience,omitempty"`
+	// Required: true
+	Audience *string `json:"audience"`
 
 	// cert pem
-	// Required: true
-	CertPem *string `json:"certPem"`
+	CertPem *string `json:"certPem,omitempty"`
 
 	// claims property
 	ClaimsProperty *string `json:"claimsProperty,omitempty"`
@@ -61,11 +61,15 @@ type ExternalJWTSignerCreate struct {
 	ExternalAuthURL *string `json:"externalAuthUrl,omitempty"`
 
 	// issuer
-	Issuer *string `json:"issuer,omitempty"`
+	// Required: true
+	Issuer *string `json:"issuer"`
+
+	// jwks endpoint
+	// Format: uri
+	JwksEndpoint *strfmt.URI `json:"jwksEndpoint,omitempty"`
 
 	// kid
-	// Required: true
-	Kid *string `json:"kid"`
+	Kid *string `json:"kid,omitempty"`
 
 	// name
 	// Example: MyApps Signer
@@ -83,7 +87,7 @@ type ExternalJWTSignerCreate struct {
 func (m *ExternalJWTSignerCreate) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateCertPem(formats); err != nil {
+	if err := m.validateAudience(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -91,7 +95,11 @@ func (m *ExternalJWTSignerCreate) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateKid(formats); err != nil {
+	if err := m.validateIssuer(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateJwksEndpoint(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -109,9 +117,9 @@ func (m *ExternalJWTSignerCreate) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ExternalJWTSignerCreate) validateCertPem(formats strfmt.Registry) error {
+func (m *ExternalJWTSignerCreate) validateAudience(formats strfmt.Registry) error {
 
-	if err := validate.Required("certPem", "body", m.CertPem); err != nil {
+	if err := validate.Required("audience", "body", m.Audience); err != nil {
 		return err
 	}
 
@@ -127,9 +135,21 @@ func (m *ExternalJWTSignerCreate) validateEnabled(formats strfmt.Registry) error
 	return nil
 }
 
-func (m *ExternalJWTSignerCreate) validateKid(formats strfmt.Registry) error {
+func (m *ExternalJWTSignerCreate) validateIssuer(formats strfmt.Registry) error {
 
-	if err := validate.Required("kid", "body", m.Kid); err != nil {
+	if err := validate.Required("issuer", "body", m.Issuer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerCreate) validateJwksEndpoint(formats strfmt.Registry) error {
+	if swag.IsZero(m.JwksEndpoint) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("jwksEndpoint", "body", "uri", m.JwksEndpoint.String(), formats); err != nil {
 		return err
 	}
 

--- a/rest_model/external_jwt_signer_detail.go
+++ b/rest_model/external_jwt_signer_detail.go
@@ -76,6 +76,11 @@ type ExternalJWTSignerDetail struct {
 	// Required: true
 	Issuer *string `json:"issuer"`
 
+	// jwks endpoint
+	// Required: true
+	// Format: uri
+	JwksEndpoint *strfmt.URI `json:"jwksEndpoint"`
+
 	// kid
 	// Required: true
 	Kid *string `json:"kid"`
@@ -127,6 +132,8 @@ func (m *ExternalJWTSignerDetail) UnmarshalJSON(raw []byte) error {
 
 		Issuer *string `json:"issuer"`
 
+		JwksEndpoint *strfmt.URI `json:"jwksEndpoint"`
+
 		Kid *string `json:"kid"`
 
 		Name *string `json:"name"`
@@ -156,6 +163,8 @@ func (m *ExternalJWTSignerDetail) UnmarshalJSON(raw []byte) error {
 	m.Fingerprint = dataAO1.Fingerprint
 
 	m.Issuer = dataAO1.Issuer
+
+	m.JwksEndpoint = dataAO1.JwksEndpoint
 
 	m.Kid = dataAO1.Kid
 
@@ -196,6 +205,8 @@ func (m ExternalJWTSignerDetail) MarshalJSON() ([]byte, error) {
 
 		Issuer *string `json:"issuer"`
 
+		JwksEndpoint *strfmt.URI `json:"jwksEndpoint"`
+
 		Kid *string `json:"kid"`
 
 		Name *string `json:"name"`
@@ -222,6 +233,8 @@ func (m ExternalJWTSignerDetail) MarshalJSON() ([]byte, error) {
 	dataAO1.Fingerprint = m.Fingerprint
 
 	dataAO1.Issuer = m.Issuer
+
+	dataAO1.JwksEndpoint = m.JwksEndpoint
 
 	dataAO1.Kid = m.Kid
 
@@ -279,6 +292,10 @@ func (m *ExternalJWTSignerDetail) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateIssuer(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateJwksEndpoint(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -374,6 +391,19 @@ func (m *ExternalJWTSignerDetail) validateFingerprint(formats strfmt.Registry) e
 func (m *ExternalJWTSignerDetail) validateIssuer(formats strfmt.Registry) error {
 
 	if err := validate.Required("issuer", "body", m.Issuer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerDetail) validateJwksEndpoint(formats strfmt.Registry) error {
+
+	if err := validate.Required("jwksEndpoint", "body", m.JwksEndpoint); err != nil {
+		return err
+	}
+
+	if err := validate.FormatOf("jwksEndpoint", "body", "uri", m.JwksEndpoint.String(), formats); err != nil {
 		return err
 	}
 

--- a/rest_model/external_jwt_signer_patch.go
+++ b/rest_model/external_jwt_signer_patch.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // ExternalJWTSignerPatch external Jwt signer patch
@@ -60,6 +61,10 @@ type ExternalJWTSignerPatch struct {
 	// issuer
 	Issuer *string `json:"issuer,omitempty"`
 
+	// jwks endpoint
+	// Format: uri
+	JwksEndpoint *strfmt.URI `json:"jwksEndpoint,omitempty"`
+
 	// kid
 	Kid *string `json:"kid,omitempty"`
 
@@ -78,6 +83,10 @@ type ExternalJWTSignerPatch struct {
 func (m *ExternalJWTSignerPatch) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateJwksEndpoint(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateTags(formats); err != nil {
 		res = append(res, err)
 	}
@@ -85,6 +94,18 @@ func (m *ExternalJWTSignerPatch) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ExternalJWTSignerPatch) validateJwksEndpoint(formats strfmt.Registry) error {
+	if swag.IsZero(m.JwksEndpoint) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("jwksEndpoint", "body", "uri", m.JwksEndpoint.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/rest_model/external_jwt_signer_update.go
+++ b/rest_model/external_jwt_signer_update.go
@@ -44,11 +44,11 @@ import (
 type ExternalJWTSignerUpdate struct {
 
 	// audience
-	Audience *string `json:"audience,omitempty"`
+	// Required: true
+	Audience *string `json:"audience"`
 
 	// cert pem
-	// Required: true
-	CertPem *string `json:"certPem"`
+	CertPem *string `json:"certPem,omitempty"`
 
 	// claims property
 	ClaimsProperty *string `json:"claimsProperty,omitempty"`
@@ -61,11 +61,15 @@ type ExternalJWTSignerUpdate struct {
 	ExternalAuthURL *string `json:"externalAuthUrl,omitempty"`
 
 	// issuer
-	Issuer *string `json:"issuer,omitempty"`
+	// Required: true
+	Issuer *string `json:"issuer"`
+
+	// jwks endpoint
+	// Format: uri
+	JwksEndpoint *strfmt.URI `json:"jwksEndpoint,omitempty"`
 
 	// kid
-	// Required: true
-	Kid *string `json:"kid"`
+	Kid *string `json:"kid,omitempty"`
 
 	// name
 	// Example: MyApps Signer
@@ -83,7 +87,7 @@ type ExternalJWTSignerUpdate struct {
 func (m *ExternalJWTSignerUpdate) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateCertPem(formats); err != nil {
+	if err := m.validateAudience(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -91,7 +95,11 @@ func (m *ExternalJWTSignerUpdate) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateKid(formats); err != nil {
+	if err := m.validateIssuer(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateJwksEndpoint(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -109,9 +117,9 @@ func (m *ExternalJWTSignerUpdate) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ExternalJWTSignerUpdate) validateCertPem(formats strfmt.Registry) error {
+func (m *ExternalJWTSignerUpdate) validateAudience(formats strfmt.Registry) error {
 
-	if err := validate.Required("certPem", "body", m.CertPem); err != nil {
+	if err := validate.Required("audience", "body", m.Audience); err != nil {
 		return err
 	}
 
@@ -127,9 +135,21 @@ func (m *ExternalJWTSignerUpdate) validateEnabled(formats strfmt.Registry) error
 	return nil
 }
 
-func (m *ExternalJWTSignerUpdate) validateKid(formats strfmt.Registry) error {
+func (m *ExternalJWTSignerUpdate) validateIssuer(formats strfmt.Registry) error {
 
-	if err := validate.Required("kid", "body", m.Kid); err != nil {
+	if err := validate.Required("issuer", "body", m.Issuer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ExternalJWTSignerUpdate) validateJwksEndpoint(formats strfmt.Registry) error {
+	if swag.IsZero(m.JwksEndpoint) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("jwksEndpoint", "body", "uri", m.JwksEndpoint.String(), formats); err != nil {
 		return err
 	}
 

--- a/specs/management.yml
+++ b/specs/management.yml
@@ -13984,15 +13984,16 @@ definitions:
     type: object
     required:
     - name
-    - certPem
     - enabled
-    - kid
+    - issuer
+    - audience
     properties:
       audience:
         type: string
         x-nullable: true
       certPem:
         type: string
+        x-nullable: true
       claimsProperty:
         type: string
         x-nullable: true
@@ -14004,9 +14005,13 @@ definitions:
         x-nullable: true
       issuer:
         type: string
+      jwksEndpoint:
+        type: string
+        format: uri
         x-nullable: true
       kid:
         type: string
+        x-nullable: true
       name:
         type: string
         example: MyApps Signer
@@ -14024,6 +14029,7 @@ definitions:
       required:
       - name
       - certPem
+      - jwksEndpoint
       - enabled
       - fingerprint
       - commonName
@@ -14040,6 +14046,7 @@ definitions:
           type: string
         certPem:
           type: string
+          x-nullable: true
         claimsProperty:
           type: string
         commonName:
@@ -14053,6 +14060,10 @@ definitions:
           type: string
         issuer:
           type: string
+        jwksEndpoint:
+          type: string
+          format: uri
+          x-nullable: true
         kid:
           type: string
         name:
@@ -14093,6 +14104,10 @@ definitions:
       issuer:
         type: string
         x-nullable: true
+      jwksEndpoint:
+        type: string
+        format: uri
+        x-nullable: true
       kid:
         type: string
         x-nullable: true
@@ -14109,15 +14124,16 @@ definitions:
     type: object
     required:
     - name
-    - certPem
     - enabled
-    - kid
+    - issuer
+    - audience
     properties:
       audience:
         type: string
         x-nullable: true
       certPem:
         type: string
+        x-nullable: true
       claimsProperty:
         type: string
         x-nullable: true
@@ -14129,9 +14145,13 @@ definitions:
         x-nullable: true
       issuer:
         type: string
+      jwksEndpoint:
+        type: string
+        format: uri
         x-nullable: true
       kid:
         type: string
+        x-nullable: true
       name:
         type: string
         example: MyApps Signer

--- a/specs/source/management/ext-jwt-signers.yml
+++ b/specs/source/management/ext-jwt-signers.yml
@@ -133,7 +133,6 @@ responses:
     description: A singular External JWT Signer resource
     schema:
       $ref: '#/definitions/detailExternalJwtSignerEnvelope'
-
 definitions:
   listExternalJwtSignersEnvelope:
     type: object
@@ -169,6 +168,7 @@ definitions:
         required:
           - name
           - certPem
+          - jwksEndpoint
           - enabled
           - fingerprint
           - commonName
@@ -186,6 +186,11 @@ definitions:
             example: 'MyApps Signer'
           certPem:
             type: string
+            x-nullable: true
+          jwksEndpoint:
+            type: string
+            format: uri
+            x-nullable: true
           enabled:
             type: boolean
           fingerprint:
@@ -216,15 +221,20 @@ definitions:
     type: object
     required:
       - name
-      - certPem
       - enabled
-      - kid
+      - issuer
+      - audience
     properties:
       name:
         type: string
         example: 'MyApps Signer'
       certPem:
         type: string
+        x-nullable: true
+      jwksEndpoint:
+        type: string
+        format: uri
+        x-nullable: true
       enabled:
         type: boolean
       externalAuthUrl:
@@ -233,6 +243,7 @@ definitions:
         x-nullable: true
       kid:
         type: string
+        x-nullable: true
       claimsProperty:
         type: string
         x-nullable: true
@@ -241,7 +252,6 @@ definitions:
         x-nullable: true
       issuer:
         type: string
-        x-nullable: true
       audience:
         type: string
         x-nullable: true
@@ -251,22 +261,28 @@ definitions:
     type: object
     required:
       - name
-      - certPem
       - enabled
-      - kid
+      - issuer
+      - audience
     properties:
       name:
         type: string
         example: 'MyApps Signer'
       certPem:
         type: string
+        x-nullable: true
+      jwksEndpoint:
+        type: string
+        format: uri
+        x-nullable: true
       enabled:
         type: boolean
-      kid:
-        type: string
       externalAuthUrl:
         type: string
         format: url
+        x-nullable: true
+      kid:
+        type: string
         x-nullable: true
       claimsProperty:
         type: string
@@ -276,7 +292,6 @@ definitions:
         x-nullable: true
       issuer:
         type: string
-        x-nullable: true
       audience:
         type: string
         x-nullable: true
@@ -291,6 +306,10 @@ definitions:
         x-nullable: true
       certPem:
         type: string
+        x-nullable: true
+      jwksEndpoint:
+        type: string
+        format: uri
         x-nullable: true
       enabled:
         type: boolean

--- a/tests/auth_external_jwt_signer_test.go
+++ b/tests/auth_external_jwt_signer_test.go
@@ -57,39 +57,72 @@ func Test_Authenticate_External_Jwt(t *testing.T) {
 	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(validJwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
 	ctx.Req.NoError(err)
 	ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+
 	signerIds = append(signerIds, createResponseEnv.Data.ID)
 
-	//valid signer no issuer no audienceS
-	validJwtSignerNoIssNoAudCert, validJwtSignerNoIssNoAudPrivateKey := newSelfSignedCert("valid signer")
-	validJwtSignerCertPemNoIssNoAud := nfpem.EncodeToString(validJwtSignerNoIssNoAudCert)
+	//valid signer w/ external id
+	validExtIdJwtSignerCert, validExtIdJwtSignerPrivateKey := newSelfSignedCert("valid signer")
+	validExtIdJwtSignerCertPem := nfpem.EncodeToString(validExtIdJwtSignerCert)
 
-	validJwtSignerNoIssNoAud := &rest_model.ExternalJWTSignerCreate{
-		CertPem: &validJwtSignerCertPemNoIssNoAud,
-		Enabled: B(true),
-		Name:    S("Test JWT Signer - Enabled No Iss No Aud"),
-		Kid:     S(uuid.NewString()),
+	validExtIdJwtSigner := &rest_model.ExternalJWTSignerCreate{
+		CertPem:       &validExtIdJwtSignerCertPem,
+		Enabled:       B(true),
+		Name:          S("Test JWT Signer - Enabled - ExternalId"),
+		Kid:           S(uuid.NewString()),
+		Issuer:        S("the-very-best-iss-ext"),
+		Audience:      S("the-very-best-aud-ext"),
+		UseExternalID: B(true),
 	}
 
-	resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(validJwtSignerNoIssNoAud).SetResult(createResponseEnv).Post("/external-jwt-signers")
+	createResponseEnv = &rest_model.CreateEnvelope{}
+
+	resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(validExtIdJwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
 	ctx.Req.NoError(err)
 	ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
-	signerIds = append(signerIds, createResponseEnv.Data.ID)
 
+	validExtIdJwtSignerId := createResponseEnv.Data.ID
+
+	//valid signer w/ external id in "alt" field
+	validAltExtIdJwtSignerCert, validAltExtIdJwtSignerPrivateKey := newSelfSignedCert("valid signer")
+	validAltExtIdJwtSignerCertPem := nfpem.EncodeToString(validAltExtIdJwtSignerCert)
+
+	validAltExtIdJwtSigner := &rest_model.ExternalJWTSignerCreate{
+		CertPem:        &validAltExtIdJwtSignerCertPem,
+		Enabled:        B(true),
+		Name:           S("Test JWT Signer - Enabled - ExternalId - Alt"),
+		Kid:            S(uuid.NewString()),
+		Issuer:         S("the-very-best-iss-ext-alt"),
+		Audience:       S("the-very-best-aud-ext-alt"),
+		UseExternalID:  B(true),
+		ClaimsProperty: S("alt"),
+	}
+
+	createResponseEnv = &rest_model.CreateEnvelope{}
+
+	resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(validAltExtIdJwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+
+	validAltExtIdJwtSignerId := createResponseEnv.Data.ID
+
+	//not enabled signer
 	createResponseEnv = &rest_model.CreateEnvelope{}
 
 	notEnabledJwtSignerCert, notEnabledJwtSignerPrivateKey := newSelfSignedCert("not enabled signer")
 	notEnabledJwtSignerCertPem := nfpem.EncodeToString(notEnabledJwtSignerCert)
 
 	notEnabledJwtSigner := &rest_model.ExternalJWTSignerCreate{
-		CertPem: &notEnabledJwtSignerCertPem,
-		Enabled: B(false),
-		Name:    S("Test JWT Signer - Not Enabled"),
-		Kid:     S(uuid.NewString()),
+		CertPem:  &notEnabledJwtSignerCertPem,
+		Enabled:  B(false),
+		Name:     S("Test JWT Signer - Not Enabled"),
+		Kid:      S(uuid.NewString()),
+		Issuer:   S("test-issuer"),
+		Audience: S("test-audience"),
 	}
 
 	resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(notEnabledJwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
 	ctx.Req.NoError(err)
-	ctx.Req.Equal(http.StatusCreated, resp.StatusCode())
+	ctx.Req.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
 	signerIds = append(signerIds, createResponseEnv.Data.ID)
 
 	invalidJwtSignerCommonName := "invalid signer"
@@ -131,39 +164,8 @@ func Test_Authenticate_External_Jwt(t *testing.T) {
 
 		resp, err := ctx.newAnonymousClientApiRequest().SetResult(result).SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
 		ctx.Req.NoError(err)
-		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
 		signerIds = append(signerIds, createResponseEnv.Data.ID)
-
-		ctx.Req.NotNil(result)
-		ctx.Req.NotNil(result.Data)
-		ctx.Req.NotNil(result.Data.Token)
-	})
-
-	t.Run("authenticating with a valid jwt succeeds and no iss no aud succeeds", func(t *testing.T) {
-		ctx.testContextChanged(t)
-
-		jwtToken := jwt.New(jwt.SigningMethodES256)
-		jwtToken.Claims = jwt.StandardClaims{
-			Audience:  "i do not matter",
-			ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
-			Id:        time.Now().String(),
-			IssuedAt:  time.Now().Unix(),
-			Issuer:    "i do not matter",
-			NotBefore: time.Now().Unix(),
-			Subject:   ctx.AdminManagementSession.identityId,
-		}
-
-		jwtToken.Header["kid"] = *validJwtSignerNoIssNoAud.Kid
-
-		jwtStrSigned, err := jwtToken.SignedString(validJwtSignerNoIssNoAudPrivateKey)
-		ctx.Req.NoError(err)
-		ctx.Req.NotEmpty(jwtStrSigned)
-
-		result := &rest_model.CurrentAPISessionDetailEnvelope{}
-
-		resp, err := ctx.newAnonymousClientApiRequest().SetResult(result).SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
-		ctx.Req.NoError(err)
-		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
 
 		ctx.Req.NotNil(result)
 		ctx.Req.NotNil(result.Data)
@@ -337,5 +339,349 @@ func Test_Authenticate_External_Jwt(t *testing.T) {
 		resp, err := ctx.newAnonymousClientApiRequest().SetResult(result).SetHeader("Authorization", "Bearer 03qwjg03rjg90qr3hngq4390rng93q0rnghq430rng34r90ng4309vn439043").Post("/authenticate?method=ext-jwt")
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode())
+	})
+
+	t.Run("can authenticate with an external id", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		externalId := uuid.NewString()
+
+		authPolicyCreate := &rest_model.AuthPolicyCreate{
+			Name: S(uuid.NewString()),
+			Primary: &rest_model.AuthPolicyPrimary{
+				Cert: &rest_model.AuthPolicyPrimaryCert{
+					Allowed:           B(false),
+					AllowExpiredCerts: B(false),
+				},
+				ExtJWT: &rest_model.AuthPolicyPrimaryExtJWT{
+					Allowed:        B(true),
+					AllowedSigners: []string{validExtIdJwtSignerId},
+				},
+				Updb: &rest_model.AuthPolicyPrimaryUpdb{
+					Allowed:                B(false),
+					LockoutDurationMinutes: I(5),
+					MaxAttempts:            I(3),
+					MinPasswordLength:      I(5),
+					RequireMixedCase:       B(true),
+					RequireNumberChar:      B(true),
+					RequireSpecialChar:     B(true),
+				},
+			},
+			Secondary: &rest_model.AuthPolicySecondary{
+				RequireExtJWTSigner: nil,
+				RequireTotp:         B(false),
+			},
+		}
+		authPolicyCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(authPolicyCreate).SetResult(authPolicyCreateResult).Post("/auth-policies")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+		ctx.NotNil(authPolicyCreateResult)
+		ctx.NotNil(authPolicyCreateResult.Data)
+		ctx.NotEmpty(authPolicyCreateResult.Data.ID)
+
+		identityType := rest_model.IdentityTypeUser
+
+		identityCreate := rest_model.IdentityCreate{
+			AuthPolicyID: S(authPolicyCreateResult.Data.ID),
+			ExternalID:   S(externalId),
+			IsAdmin:      B(false),
+			Name:         S(uuid.NewString()),
+			Type:         &identityType,
+		}
+
+		identityCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(identityCreate).SetResult(identityCreateResult).Post("/identities")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode())
+		ctx.NotNil(identityCreateResult)
+		ctx.NotNil(identityCreateResult.Data)
+		ctx.NotEmpty(identityCreateResult.Data.ID)
+
+		jwtToken := jwt.New(jwt.SigningMethodES256)
+		jwtToken.Claims = jwt.StandardClaims{
+			Audience:  *validExtIdJwtSigner.Audience,
+			ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
+			Id:        time.Now().String(),
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    *validExtIdJwtSigner.Issuer,
+			NotBefore: time.Now().Unix(),
+			Subject:   externalId,
+		}
+
+		jwtToken.Header["kid"] = *validExtIdJwtSigner.Kid
+
+		jwtStrSigned, err := jwtToken.SignedString(validExtIdJwtSignerPrivateKey)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(jwtStrSigned)
+
+		result := &rest_model.CurrentAPISessionDetailEnvelope{}
+
+		resp, err := ctx.newAnonymousClientApiRequest().SetResult(result).SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		ctx.Req.NotNil(result)
+		ctx.Req.NotNil(result.Data)
+		ctx.Req.NotNil(result.Data.Token)
+	})
+
+	t.Run("can not authenticate with an invalid external id", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		externalId := uuid.NewString()
+
+		authPolicyCreate := &rest_model.AuthPolicyCreate{
+			Name: S(uuid.NewString()),
+			Primary: &rest_model.AuthPolicyPrimary{
+				Cert: &rest_model.AuthPolicyPrimaryCert{
+					Allowed:           B(false),
+					AllowExpiredCerts: B(false),
+				},
+				ExtJWT: &rest_model.AuthPolicyPrimaryExtJWT{
+					Allowed:        B(true),
+					AllowedSigners: []string{validExtIdJwtSignerId},
+				},
+				Updb: &rest_model.AuthPolicyPrimaryUpdb{
+					Allowed:                B(false),
+					LockoutDurationMinutes: I(5),
+					MaxAttempts:            I(3),
+					MinPasswordLength:      I(5),
+					RequireMixedCase:       B(true),
+					RequireNumberChar:      B(true),
+					RequireSpecialChar:     B(true),
+				},
+			},
+			Secondary: &rest_model.AuthPolicySecondary{
+				RequireExtJWTSigner: nil,
+				RequireTotp:         B(false),
+			},
+		}
+		authPolicyCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(authPolicyCreate).SetResult(authPolicyCreateResult).Post("/auth-policies")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+		ctx.NotNil(authPolicyCreateResult)
+		ctx.NotNil(authPolicyCreateResult.Data)
+		ctx.NotEmpty(authPolicyCreateResult.Data.ID)
+
+		identityType := rest_model.IdentityTypeUser
+
+		identityCreate := rest_model.IdentityCreate{
+			AuthPolicyID: S(authPolicyCreateResult.Data.ID),
+			ExternalID:   S(externalId),
+			IsAdmin:      B(false),
+			Name:         S(uuid.NewString()),
+			Type:         &identityType,
+		}
+
+		identityCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(identityCreate).SetResult(identityCreateResult).Post("/identities")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode())
+		ctx.NotNil(identityCreateResult)
+		ctx.NotNil(identityCreateResult.Data)
+		ctx.NotEmpty(identityCreateResult.Data.ID)
+
+		jwtToken := jwt.New(jwt.SigningMethodES256)
+		jwtToken.Claims = jwt.StandardClaims{
+			Audience:  *validExtIdJwtSigner.Audience,
+			ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
+			Id:        time.Now().String(),
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    *validExtIdJwtSigner.Issuer,
+			NotBefore: time.Now().Unix(),
+			Subject:   uuid.NewString(),
+		}
+
+		jwtToken.Header["kid"] = *validExtIdJwtSigner.Kid
+
+		jwtStrSigned, err := jwtToken.SignedString(validExtIdJwtSignerPrivateKey)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(jwtStrSigned)
+
+		resp, err := ctx.newAnonymousClientApiRequest().SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(), string(resp.Body()))
+	})
+
+	t.Run("can not authenticate with an external id signed by the wrong signer", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		externalId := uuid.NewString()
+
+		authPolicyCreate := &rest_model.AuthPolicyCreate{
+			Name: S(uuid.NewString()),
+			Primary: &rest_model.AuthPolicyPrimary{
+				Cert: &rest_model.AuthPolicyPrimaryCert{
+					Allowed:           B(false),
+					AllowExpiredCerts: B(false),
+				},
+				ExtJWT: &rest_model.AuthPolicyPrimaryExtJWT{
+					Allowed:        B(true),
+					AllowedSigners: []string{validExtIdJwtSignerId},
+				},
+				Updb: &rest_model.AuthPolicyPrimaryUpdb{
+					Allowed:                B(false),
+					LockoutDurationMinutes: I(5),
+					MaxAttempts:            I(3),
+					MinPasswordLength:      I(5),
+					RequireMixedCase:       B(true),
+					RequireNumberChar:      B(true),
+					RequireSpecialChar:     B(true),
+				},
+			},
+			Secondary: &rest_model.AuthPolicySecondary{
+				RequireExtJWTSigner: nil,
+				RequireTotp:         B(false),
+			},
+		}
+		authPolicyCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(authPolicyCreate).SetResult(authPolicyCreateResult).Post("/auth-policies")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+		ctx.NotNil(authPolicyCreateResult)
+		ctx.NotNil(authPolicyCreateResult.Data)
+		ctx.NotEmpty(authPolicyCreateResult.Data.ID)
+
+		identityType := rest_model.IdentityTypeUser
+
+		identityCreate := rest_model.IdentityCreate{
+			AuthPolicyID: S(authPolicyCreateResult.Data.ID),
+			ExternalID:   S(externalId),
+			IsAdmin:      B(false),
+			Name:         S(uuid.NewString()),
+			Type:         &identityType,
+		}
+
+		identityCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(identityCreate).SetResult(identityCreateResult).Post("/identities")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode())
+		ctx.NotNil(identityCreateResult)
+		ctx.NotNil(identityCreateResult.Data)
+		ctx.NotEmpty(identityCreateResult.Data.ID)
+
+		jwtToken := jwt.New(jwt.SigningMethodES256)
+		jwtToken.Claims = jwt.StandardClaims{
+			Audience:  *validExtIdJwtSigner.Audience,
+			ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
+			Id:        time.Now().String(),
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    *validExtIdJwtSigner.Issuer,
+			NotBefore: time.Now().Unix(),
+			Subject:   externalId,
+		}
+
+		jwtToken.Header["kid"] = *validExtIdJwtSigner.Kid
+
+		jwtStrSigned, err := jwtToken.SignedString(notEnabledJwtSignerPrivateKey)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(jwtStrSigned)
+
+		resp, err := ctx.newAnonymousClientApiRequest().SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(), string(resp.Body()))
+	})
+
+	t.Run("can authenticate with an external id in a non-sub (alt) field", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		externalId := uuid.NewString()
+
+		authPolicyCreate := &rest_model.AuthPolicyCreate{
+			Name: S(uuid.NewString()),
+			Primary: &rest_model.AuthPolicyPrimary{
+				Cert: &rest_model.AuthPolicyPrimaryCert{
+					Allowed:           B(false),
+					AllowExpiredCerts: B(false),
+				},
+				ExtJWT: &rest_model.AuthPolicyPrimaryExtJWT{
+					Allowed:        B(true),
+					AllowedSigners: []string{validAltExtIdJwtSignerId},
+				},
+				Updb: &rest_model.AuthPolicyPrimaryUpdb{
+					Allowed:                B(false),
+					LockoutDurationMinutes: I(5),
+					MaxAttempts:            I(3),
+					MinPasswordLength:      I(5),
+					RequireMixedCase:       B(true),
+					RequireNumberChar:      B(true),
+					RequireSpecialChar:     B(true),
+				},
+			},
+			Secondary: &rest_model.AuthPolicySecondary{
+				RequireExtJWTSigner: nil,
+				RequireTotp:         B(false),
+			},
+		}
+		authPolicyCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(authPolicyCreate).SetResult(authPolicyCreateResult).Post("/auth-policies")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+		ctx.NotNil(authPolicyCreateResult)
+		ctx.NotNil(authPolicyCreateResult.Data)
+		ctx.NotEmpty(authPolicyCreateResult.Data.ID)
+
+		identityType := rest_model.IdentityTypeUser
+
+		identityCreate := rest_model.IdentityCreate{
+			AuthPolicyID: S(authPolicyCreateResult.Data.ID),
+			ExternalID:   S(externalId),
+			IsAdmin:      B(false),
+			Name:         S(uuid.NewString()),
+			Type:         &identityType,
+		}
+
+		identityCreateResult := &rest_model.CreateEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(identityCreate).SetResult(identityCreateResult).Post("/identities")
+		ctx.NoError(err)
+		ctx.Equal(http.StatusCreated, resp.StatusCode())
+		ctx.NotNil(identityCreateResult)
+		ctx.NotNil(identityCreateResult.Data)
+		ctx.NotEmpty(identityCreateResult.Data.ID)
+
+		type altClaims struct {
+			jwt.StandardClaims
+			Alt string `json:"alt,omitempty"`
+		}
+
+		jwtToken := jwt.New(jwt.SigningMethodES256)
+		jwtToken.Claims = altClaims{
+			StandardClaims: jwt.StandardClaims{
+				Audience:  *validAltExtIdJwtSigner.Audience,
+				ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
+				Id:        time.Now().String(),
+				IssuedAt:  time.Now().Unix(),
+				Issuer:    *validAltExtIdJwtSigner.Issuer,
+				NotBefore: time.Now().Unix(),
+				Subject:   uuid.NewString(),
+			},
+			Alt: externalId,
+		}
+
+		jwtToken.Header["kid"] = *validAltExtIdJwtSigner.Kid
+
+		jwtStrSigned, err := jwtToken.SignedString(validAltExtIdJwtSignerPrivateKey)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(jwtStrSigned)
+
+		result := &rest_model.CurrentAPISessionDetailEnvelope{}
+
+		resp, err := ctx.newAnonymousClientApiRequest().SetResult(result).SetHeader("Authorization", "Bearer "+jwtStrSigned).Post("/authenticate?method=ext-jwt")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		ctx.Req.NotNil(result)
+		ctx.Req.NotNil(result.Data)
+		ctx.Req.NotNil(result.Data.Token)
 	})
 }

--- a/tests/auth_policy_test.go
+++ b/tests/auth_policy_test.go
@@ -41,10 +41,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-99"),
+			Audience: S("test-audience-99"),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -232,10 +234,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Patch")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy Patch"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy Patch"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-100"),
+			Audience: S("test-audience-100"),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -338,10 +342,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Patch")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy Patch1"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy Patch1"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-101"),
+			Audience: S("test-audience-101"),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -536,10 +542,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert1, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy - Delete Scenarios 1")
 
 		extJwtSigner1 := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert1)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Delete Scenarios 1"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert1)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Delete Scenarios 1"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-102"),
+			Audience: S("test-audience-102"),
 		}
 
 		extJwtSignerCreated1 := &rest_model.CreateEnvelope{}
@@ -551,10 +559,12 @@ func Test_AuthPolicies(t *testing.T) {
 
 		jwtSignerCert2, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy - Delete Scenarios 2")
 		extJwtSigner2 := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert2)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Delete Scenarios 2"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert2)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Delete Scenarios 2"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-200"),
+			Audience: S("test-audience-200"),
 		}
 
 		extJwtSignerCreated2 := &rest_model.CreateEnvelope{}
@@ -798,10 +808,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert, _ := newSelfSignedCert("Test Jwt Signer Cert - Update Default")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Update Default"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Update Default"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-104"),
+			Audience: S("test-audience-104"),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -917,10 +929,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCert, _ := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy 08")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy 08"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy 08"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-105"),
+			Audience: S("test-audience-105"),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -1113,10 +1127,12 @@ func Test_AuthPolicies(t *testing.T) {
 			jwtSignerCert, jwtSignerPrivate := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Not Allowed 01")
 
 			extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-				CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-				Enabled: B(true),
-				Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Not Allowed 01"),
-				Kid:     S(uuid.NewString()),
+				CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+				Enabled:  B(true),
+				Name:     S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Not Allowed 01"),
+				Kid:      S(uuid.NewString()),
+				Issuer:   S("test-issuer-106"),
+				Audience: S("test-audience-106"),
 			}
 
 			extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -1173,10 +1189,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCertAllowed, jwtSignerPrivateAllowed := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Allowed 01")
 
 		extJwtSignerAllowed := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCertAllowed)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 01"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCertAllowed)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 01"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-107"),
+			Audience: S("test-audience-107"),
 		}
 
 		extJwtSignerCreatedAllowed := &rest_model.CreateEnvelope{}
@@ -1189,10 +1207,12 @@ func Test_AuthPolicies(t *testing.T) {
 		jwtSignerCertNotAllowed, jwtSignerPrivateNotAllowed := newSelfSignedCert("Test Jwt Signer Cert - Auth Policy Ext JWT Not Allowed 02")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCertNotAllowed)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 02"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCertNotAllowed)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT Limited 02"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S("test-issuer-108"),
+			Audience: S("test-audience-108"),
 		}
 
 		extJwtSignerCreatedNotAllowed := &rest_model.CreateEnvelope{}
@@ -1257,11 +1277,11 @@ func Test_AuthPolicies(t *testing.T) {
 		t.Run("can authenticate with approved external jwt signer", func(t *testing.T) {
 			jwtToken := jwt.New(jwt.SigningMethodES256)
 			jwtToken.Claims = jwt.StandardClaims{
-				Audience:  "ziti.controller",
 				ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
 				Id:        time.Now().String(),
 				IssuedAt:  time.Now().Unix(),
-				Issuer:    "fake.issuer",
+				Issuer:    "test-issuer-107",
+				Audience:  "test-audience-107",
 				NotBefore: time.Now().Unix(),
 				Subject:   identityExtJwtCreated.Data.ID,
 			}
@@ -1318,6 +1338,8 @@ func Test_AuthPolicies(t *testing.T) {
 			Name:            S("Test JWT Signer - Auth Policy - Auth Policy Ext JWT FA 01"),
 			ExternalAuthURL: S("https://get.some.jwt.here"),
 			Kid:             S(uuid.NewString()),
+			Issuer:          S("test-issuer-109"),
+			Audience:        S("test-audience-109"),
 		}
 
 		extJwtSignerCreatedAllowed := &rest_model.CreateEnvelope{}
@@ -1415,11 +1437,11 @@ func Test_AuthPolicies(t *testing.T) {
 
 				jwtToken := jwt.New(jwt.SigningMethodES256)
 				jwtToken.Claims = jwt.StandardClaims{
-					Audience:  "ziti.controller",
 					ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
 					Id:        time.Now().String(),
 					IssuedAt:  time.Now().Unix(),
-					Issuer:    "fake.issuer",
+					Issuer:    "test-issuer-109",
+					Audience:  "test-audience-109",
 					NotBefore: time.Now().Unix(),
 					Subject:   identityExtJwtCreated.Data.ID,
 				}

--- a/tests/identity_test.go
+++ b/tests/identity_test.go
@@ -660,10 +660,12 @@ func Test_Identity(t *testing.T) {
 		jwtSignerCert, jwtSignerPrivate := newSelfSignedCert("Test Jwt Signer Cert - Identity Disabled Test 01")
 
 		extJwtSigner := &rest_model.ExternalJWTSignerCreate{
-			CertPem: S(nfpem.EncodeToString(jwtSignerCert)),
-			Enabled: B(true),
-			Name:    S("Test JWT Signer - Auth Policy - Identity Disable Test 01"),
-			Kid:     S(uuid.NewString()),
+			CertPem:  S(nfpem.EncodeToString(jwtSignerCert)),
+			Enabled:  B(true),
+			Name:     S("Test JWT Signer - Auth Policy - Identity Disable Test 01"),
+			Kid:      S(uuid.NewString()),
+			Issuer:   S(uuid.NewString()),
+			Audience: S(uuid.NewString()),
 		}
 
 		extJwtSignerCreated := &rest_model.CreateEnvelope{}
@@ -703,11 +705,11 @@ func Test_Identity(t *testing.T) {
 
 			jwtToken := jwt.New(jwt.SigningMethodES256)
 			jwtToken.Claims = jwt.StandardClaims{
-				Audience:  "ziti.controller",
+				Audience:  *extJwtSigner.Audience,
 				ExpiresAt: time.Now().Add(2 * time.Hour).Unix(),
 				Id:        time.Now().String(),
 				IssuedAt:  time.Now().Unix(),
-				Issuer:    "fake.issuer",
+				Issuer:    *extJwtSigner.Issuer,
 				NotBefore: time.Now().Unix(),
 				Subject:   identityCreated.Data.ID,
 			}


### PR DESCRIPTION
- ext-jwt-signers now support jwks endpoints in addition to static
  certificates
- ext-jwt-signers now require either kid+cert or jkwsEndpoint
- ext-jwt-signers now requires issuer and audience fields
- jwksEndpoints are initially cached and will be revalidated on invalid
  auth once every 5s at most
- adds external id tests