### PR TITLE
Fix heartbeat deadlock. Fixes #1303

### DIFF
--- a/controller/model/api_session_heartbeats.go
+++ b/controller/model/api_session_heartbeats.go
@@ -112,9 +112,11 @@ func (self *HeartbeatCollector) flush() {
 
 		var beats []*Heartbeat
 
+		var buckets [][]*Heartbeat
+
 		self.apiSessionLastAccessedAtMap.IterCb(func(key string, status *HeartbeatStatus) {
 			if len(beats) >= self.batchSize {
-				self.flushAction(beats)
+				buckets = append(buckets, beats)
 				beats = nil
 			}
 
@@ -126,6 +128,10 @@ func (self *HeartbeatCollector) flush() {
 				})
 			}
 		})
+
+		for _, bucket := range buckets {
+			self.flushAction(bucket)
+		}
 
 		if len(beats) > 0 {
 			self.flushAction(beats)

--- a/controller/model/edge_service_manager.go
+++ b/controller/model/edge_service_manager.go
@@ -355,7 +355,7 @@ func (self *EdgeServiceManager) GetPolicyPostureChecks(identityId, serviceId str
 			for cursor.IsValid() {
 				checkId := string(cursor.Current())
 				if postureCheck, found := postureCheckCache[checkId]; !found {
-					postureCheck, _ := self.env.GetManagers().PostureCheck.Read(checkId)
+					postureCheck, _ := self.env.GetManagers().PostureCheck.readInTx(tx, checkId)
 					postureCheckCache[checkId] = postureCheck
 					policyIdToChecks[policyIdStr].PostureChecks = append(policyIdToChecks[policyIdStr].PostureChecks, postureCheck)
 				} else {


### PR DESCRIPTION
bbolt batch was trying to finish commit, needed all txes to finish heartbeat update in read tx was waiting for concurrent status map so it could update heartbeat status map was locked iterating waiting to submit to batch (now we're back at the beginning)
Was also a view tx within a view tx, which can be problematic