### PR TITLE
fixes #1416 allows totp provisioning URL domain to be configured

### DIFF
--- a/controller/model/mfa_manager.go
+++ b/controller/model/mfa_manager.go
@@ -224,7 +224,7 @@ func (self *MfaManager) GetProvisioningUrl(mfa *Mfa) string {
 		WindowSize: WindowSizeTOTP,
 		UTC:        true,
 	}
-	return otcConfig.ProvisionURIWithIssuer(mfa.Identity.Name, "ziti.dev")
+	return otcConfig.ProvisionURIWithIssuer(mfa.Identity.Name, self.env.GetConfig().Totp.Hostname)
 }
 
 func (self *MfaManager) RecreateRecoveryCodes(mfa *Mfa, ctx *change.Context) error {

--- a/tests/mfa_ziti_test.go
+++ b/tests/mfa_ziti_test.go
@@ -212,7 +212,8 @@ func Test_MFA(t *testing.T) {
 				mfaUrl, err := url.Parse(provisionString)
 				ctx.Req.NoError(err)
 				ctx.Req.Equal(mfaUrl.Host, "totp")
-				ctx.Req.Equal(mfaUrl.Path, "/ziti.dev:"+mfaStartedIdentityName)
+
+				ctx.Req.Equal(mfaUrl.Path, "/"+ctx.EdgeController.AppEnv.Config.Totp.Hostname+":"+mfaStartedIdentityName)
 				ctx.Req.Equal(mfaUrl.Scheme, "otpauth")
 			})
 		})


### PR DESCRIPTION
- sets the default to openziti.io (previously ziti.dev)
- adds `edge.totp` configuration section
- `edge.totp.hostname` now used in MFA TOTP provisioning URL generation