### PR TITLE
Fix cert expire check logic error

### DIFF
--- a/controller/model/authenticator_mod_cert.go
+++ b/controller/model/authenticator_mod_cert.go
@@ -214,7 +214,7 @@ func (module *AuthModuleCert) Process(context AuthContext) (AuthResult, error) {
 	}
 
 	if !authPolicy.Primary.Cert.AllowExpiredCerts {
-		if module.isCertExpirationValid(clientCert) {
+		if !module.isCertExpirationValid(clientCert) {
 			logger.Error("failed to verify expiration period of client certificate")
 			return nil, apierror.NewInvalidAuth()
 		}


### PR DESCRIPTION
When auth policies are used, and primary cert expiration checks are required, the current check only succeeds when the cert is expired or not yet valid. Add a `not` to the check to get the expected results.