### PR TITLE
fix nil list on auth policy rest model, fixes #1584

### DIFF
--- a/controller/internal/routes/auth_policy_api_model.go
+++ b/controller/internal/routes/auth_policy_api_model.go
@@ -62,6 +62,10 @@ func MapAuthPolicyToRestModel(model *model.AuthPolicy) (*rest_model.AuthPolicyDe
 		},
 	}
 
+	if ret.Primary.ExtJWT.AllowedSigners == nil {
+		ret.Primary.ExtJWT.AllowedSigners = []string{}
+	}
+
 	return ret, nil
 }
 


### PR DESCRIPTION
Some languages do not equate nil/null with empty list or list types.