### PR TITLE
call shutdown on the ctrl config after initializing

### DIFF
--- a/controller/subcmd/init.go
+++ b/controller/subcmd/init.go
@@ -101,6 +101,8 @@ func NewEdgeInitializeCmd(versionProvider versions.VersionProvider) *cobra.Comma
 			if err := ctrl.AppEnv.Managers.Identity.InitializeDefaultAdmin(options.username, options.password, options.name); err != nil {
 				pfxlog.Logger().Fatal(err)
 			}
+			ctrl.Shutdown()
+
 			pfxlog.Logger().Info("Ziti Edge initialization complete")
 		},
 	}


### PR DESCRIPTION
in order to initialize, then run a controller in a single process the initialization needs to close the db