### PR TITLE
entity change event fixes

### DIFF
--- a/controller/handler_edge_ctrl/common_tunnel.go
+++ b/controller/handler_edge_ctrl/common_tunnel.go
@@ -341,25 +341,36 @@ func (self *baseTunnelRequestContext) getCreateSessionResponse() *edge_ctrl_pb.C
 
 func (self *baseTunnelRequestContext) updateIdentityInfo(envInfo *edge_ctrl_pb.EnvInfo, sdkInfo *edge_ctrl_pb.SdkInfo) {
 	if self.err == nil {
+		updateIdentity := false
 		if envInfo != nil {
-			self.identity.EnvInfo = &model.EnvInfo{}
-			self.identity.EnvInfo.Arch = envInfo.Arch
-			self.identity.EnvInfo.Os = envInfo.Os
-			self.identity.EnvInfo.OsRelease = envInfo.OsRelease
-			self.identity.EnvInfo.OsVersion = envInfo.OsVersion
+			newEnvInfo := &model.EnvInfo{
+				Arch:      envInfo.Arch,
+				Os:        envInfo.Os,
+				OsRelease: envInfo.OsRelease,
+				OsVersion: envInfo.OsVersion,
+			}
+			if !self.identity.EnvInfo.Equals(newEnvInfo) {
+				self.identity.EnvInfo = newEnvInfo
+				updateIdentity = true
+			}
 		}
 
 		if sdkInfo != nil {
-			self.identity.SdkInfo = &model.SdkInfo{}
-			self.identity.SdkInfo.AppId = sdkInfo.AppId
-			self.identity.SdkInfo.AppVersion = sdkInfo.AppVersion
-			self.identity.SdkInfo.Branch = sdkInfo.Branch
-			self.identity.SdkInfo.Revision = sdkInfo.Revision
-			self.identity.SdkInfo.Type = sdkInfo.Type
-			self.identity.SdkInfo.Version = sdkInfo.Version
+			newSdkInfo := &model.SdkInfo{
+				AppId:      sdkInfo.AppId,
+				AppVersion: sdkInfo.AppVersion,
+				Branch:     sdkInfo.Branch,
+				Revision:   sdkInfo.Revision,
+				Type:       sdkInfo.Type,
+				Version:    sdkInfo.Version,
+			}
+			if !self.identity.SdkInfo.Equals(newSdkInfo) {
+				self.identity.SdkInfo = newSdkInfo
+				updateIdentity = true
+			}
 		}
 
-		if envInfo != nil || sdkInfo != nil {
+		if updateIdentity {
 			self.err = internalError(self.handler.getAppEnv().GetManagers().Identity.PatchInfo(self.identity, self.newTunnelChangeContext()))
 		}
 	}

--- a/controller/model/identity_model.go
+++ b/controller/model/identity_model.go
@@ -33,6 +33,19 @@ type EnvInfo struct {
 	OsVersion string
 }
 
+func (self *EnvInfo) Equals(other *EnvInfo) bool {
+	if self == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+	return self.Arch == other.Arch &&
+		self.Os == other.Os &&
+		self.OsRelease == other.OsRelease &&
+		self.OsVersion == other.OsVersion
+}
+
 type SdkInfo struct {
 	AppId      string
 	AppVersion string
@@ -40,6 +53,21 @@ type SdkInfo struct {
 	Revision   string
 	Type       string
 	Version    string
+}
+
+func (self *SdkInfo) Equals(other *SdkInfo) bool {
+	if self == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+	return self.AppId == other.AppId &&
+		self.AppVersion == other.AppVersion &&
+		self.Branch == other.Branch &&
+		self.Revision == other.Revision &&
+		self.Type == other.Type &&
+		self.Version == other.Version
 }
 
 type Identity struct {

--- a/controller/persistence/api_session_store.go
+++ b/controller/persistence/api_session_store.go
@@ -47,7 +47,7 @@ const (
 type ApiSession struct {
 	boltz.BaseExtEntity
 	IdentityId      string    `json:"identityId"`
-	Token           string    `json:"token"`
+	Token           string    `json:"-"`
 	IPAddress       string    `json:"ipAddress"`
 	ConfigTypes     []string  `json:"configTypes"`
 	MfaComplete     bool      `json:"mfaComplete"`

--- a/controller/persistence/enrollment_store.go
+++ b/controller/persistence/enrollment_store.go
@@ -52,7 +52,7 @@ type Enrollment struct {
 	IssuedAt        *time.Time `json:"issuedAt"`
 	CaId            *string    `json:"caId"`
 	Username        *string    `json:"username"`
-	Jwt             string     `json:"jwt"`
+	Jwt             string     `json:"-"`
 }
 
 func (entity *Enrollment) GetEntityType() string {

--- a/controller/persistence/session_store.go
+++ b/controller/persistence/session_store.go
@@ -42,7 +42,7 @@ var validSessionTypes = []string{SessionTypeDial, SessionTypeBind}
 
 type Session struct {
 	boltz.BaseExtEntity
-	Token           string      `json:"token"`
+	Token           string      `json:"-"`
 	IdentityId      string      `json:"identityId"`
 	ApiSessionId    string      `json:"apiSessionId"`
 	ServiceId       string      `json:"serviceId"`


### PR DESCRIPTION
- Don't emit session tokens or JWTs. Fixes #1599
- Don't update identity if it hasn't changed. Fix change attribution for edge client updates. Fixes #1610. Fixes #1611
