### PR TITLE
fixes openziti/ziti#1310 enrollment extension waits for controller

### DIFF
--- a/router/internal/edgerouter/config.go
+++ b/router/internal/edgerouter/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	SessionValidateMinInterval time.Duration
 	SessionValidateMaxInterval time.Duration
 	Tcfg                       transport.Configuration
-	ExtendEnrollment           bool
+	ForceExtendEnrollment      bool
 
 	RouterConfig             *router.Config
 	EnrollmentIdentityConfig *identity.Config
@@ -113,7 +113,7 @@ func (config *Config) LoadConfigFromMap(configMap map[interface{}]interface{}) e
 	if val, ok := configMap[FlagsCfgMapKey]; ok {
 		if flags, ok := val.(map[string]*pflag.Flag); ok {
 			if flag, ok := flags["extend"]; ok {
-				config.ExtendEnrollment = flag.Value.String() == "true"
+				config.ForceExtendEnrollment = flag.Value.String() == "true"
 			}
 		}
 	}

--- a/router/xgress_edge/certchecker_test.go
+++ b/router/xgress_edge/certchecker_test.go
@@ -236,19 +236,6 @@ func Test_CertExpirationChecker(t *testing.T) {
 			req.GreaterOrEqual(waitTime, 20*time.Second)
 			req.LessOrEqual(waitTime, 30*time.Second)
 		})
-
-		t.Run("force returns 0", func(t *testing.T) {
-			req := require.New(t)
-			certChecker, _ := newCertChecker()
-
-			certChecker.edgeConfig.ExtendEnrollment = true
-
-			waitTime, err := certChecker.getWaitTime()
-
-			req.NoError(err)
-			req.Equal(time.Duration(0), waitTime)
-			req.False(certChecker.edgeConfig.ExtendEnrollment)
-		})
 	})
 
 	t.Run("Run", func(t *testing.T) {
@@ -370,19 +357,6 @@ func Test_CertExpirationChecker(t *testing.T) {
 	})
 
 	t.Run("ExtendEnrollment", func(t *testing.T) {
-		t.Run("errors if control channel is closed", func(t *testing.T) {
-			req := require.New(t)
-			certChecker, _ := newCertChecker()
-
-			testChannel := certChecker.ctrls.AnyCtrlChannel().(*simpleTestChannel)
-			req.NotNil(testChannel)
-			testChannel.isClosed = true
-
-			err := certChecker.ExtendEnrollment()
-
-			req.Error(err)
-			req.True(certChecker.isRequesting.Load())
-		})
 
 		t.Run("errors if isRequesting = true", func(t *testing.T) {
 			req := require.New(t)


### PR DESCRIPTION
For router certificate extension, routers now wait for a control channel for 10s then check again every one minute till it is available or the router is terminated or self terminates due to a lack of a control channel.